### PR TITLE
chore: update sign flow and add fee calculations

### DIFF
--- a/docs/typescript/core/classes/Core.SundaeSDK.md
+++ b/docs/typescript/core/classes/Core.SundaeSDK.md
@@ -66,7 +66,7 @@ ___
 
 ### deposit
 
-▸ **deposit**(`config`): `Promise`<[`ITxBuilderComplete`](../interfaces/Core.ITxBuilderComplete.md)\>
+▸ **deposit**(`config`): `Promise`<[`ITxBuilderTx`](../interfaces/Core.ITxBuilderTx.md)\>
 
 Create a Deposit transaction for a pool by supplying two assets.
 
@@ -78,7 +78,7 @@ Create a Deposit transaction for a pool by supplying two assets.
 
 #### Returns
 
-`Promise`<[`ITxBuilderComplete`](../interfaces/Core.ITxBuilderComplete.md)\>
+`Promise`<[`ITxBuilderTx`](../interfaces/Core.ITxBuilderTx.md)\>
 
 #### Defined in
 
@@ -88,7 +88,7 @@ ___
 
 ### limitSwap
 
-▸ **limitSwap**(`config`, `limitPrice`): `Promise`<[`ITxBuilderComplete`](../interfaces/Core.ITxBuilderComplete.md)\>
+▸ **limitSwap**(`config`, `limitPrice`): `Promise`<[`ITxBuilderTx`](../interfaces/Core.ITxBuilderTx.md)\>
 
 Creates a swap with a minimum receivable limit price. The price should be the minimum
 amount at which you want the order to execute. For example:
@@ -126,7 +126,7 @@ const { submit, cbor } = await SDK.limitSwap(
 
 #### Returns
 
-`Promise`<[`ITxBuilderComplete`](../interfaces/Core.ITxBuilderComplete.md)\>
+`Promise`<[`ITxBuilderTx`](../interfaces/Core.ITxBuilderTx.md)\>
 
 #### Defined in
 
@@ -152,7 +152,7 @@ ___
 
 ### swap
 
-▸ **swap**(`config`, `slippage?`): `Promise`<[`ITxBuilderComplete`](../interfaces/Core.ITxBuilderComplete.md)\>
+▸ **swap**(`config`, `slippage?`): `Promise`<[`ITxBuilderTx`](../interfaces/Core.ITxBuilderTx.md)\>
 
 The main entry point for building a swap transaction with the least amount
 of configuration required. By default, all calls to this method are treated
@@ -209,7 +209,7 @@ const { submit, cbor } = await SDK.swap(
 
 #### Returns
 
-`Promise`<[`ITxBuilderComplete`](../interfaces/Core.ITxBuilderComplete.md)\>
+`Promise`<[`ITxBuilderTx`](../interfaces/Core.ITxBuilderTx.md)\>
 
 #### Defined in
 
@@ -219,7 +219,7 @@ ___
 
 ### unstable\_zap
 
-▸ **unstable_zap**(`config`): `Promise`<[`ITxBuilderComplete`](../interfaces/Core.ITxBuilderComplete.md)\>
+▸ **unstable_zap**(`config`): `Promise`<[`ITxBuilderTx`](../interfaces/Core.ITxBuilderTx.md)\>
 
 Create a Deposit transaction for a pool by supplying two assets.
 
@@ -231,7 +231,7 @@ Create a Deposit transaction for a pool by supplying two assets.
 
 #### Returns
 
-`Promise`<[`ITxBuilderComplete`](../interfaces/Core.ITxBuilderComplete.md)\>
+`Promise`<[`ITxBuilderTx`](../interfaces/Core.ITxBuilderTx.md)\>
 
 #### Defined in
 
@@ -241,7 +241,7 @@ ___
 
 ### withdraw
 
-▸ **withdraw**(`config`): `Promise`<[`ITxBuilderComplete`](../interfaces/Core.ITxBuilderComplete.md)\>
+▸ **withdraw**(`config`): `Promise`<[`ITxBuilderTx`](../interfaces/Core.ITxBuilderTx.md)\>
 
 Create a Withdraw transaction for a pool by supplying the LP tokens.
 
@@ -253,7 +253,7 @@ Create a Withdraw transaction for a pool by supplying the LP tokens.
 
 #### Returns
 
-`Promise`<[`ITxBuilderComplete`](../interfaces/Core.ITxBuilderComplete.md)\>
+`Promise`<[`ITxBuilderTx`](../interfaces/Core.ITxBuilderTx.md)\>
 
 #### Defined in
 

--- a/docs/typescript/core/classes/Core.TxBuilder.md
+++ b/docs/typescript/core/classes/Core.TxBuilder.md
@@ -23,7 +23,7 @@ The main class by which TxBuilder classes are extended.
 
 ### buildCancelTx
 
-▸ `Abstract` **buildCancelTx**(`args`): `Promise`<[`ITxBuilderComplete`](../interfaces/Core.ITxBuilderComplete.md)\>
+▸ `Abstract` **buildCancelTx**(`args`): `Promise`<[`ITxBuilderTx`](../interfaces/Core.ITxBuilderTx.md)\>
 
 The main function to build a cancellation Transaction.
 
@@ -35,17 +35,17 @@ The main function to build a cancellation Transaction.
 
 #### Returns
 
-`Promise`<[`ITxBuilderComplete`](../interfaces/Core.ITxBuilderComplete.md)\>
+`Promise`<[`ITxBuilderTx`](../interfaces/Core.ITxBuilderTx.md)\>
 
 #### Defined in
 
-[classes/Abstracts/TxBuilder.abstract.class.ts:75](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/classes/Abstracts/TxBuilder.abstract.class.ts#L75)
+[classes/Abstracts/TxBuilder.abstract.class.ts:73](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/classes/Abstracts/TxBuilder.abstract.class.ts#L73)
 
 ___
 
 ### buildDepositTx
 
-▸ `Abstract` **buildDepositTx**(`args`): `Promise`<[`ITxBuilderComplete`](../interfaces/Core.ITxBuilderComplete.md)\>
+▸ `Abstract` **buildDepositTx**(`args`): `Promise`<[`ITxBuilderTx`](../interfaces/Core.ITxBuilderTx.md)\>
 
 The main function to build a deposit Transaction.
 
@@ -57,7 +57,7 @@ The main function to build a deposit Transaction.
 
 #### Returns
 
-`Promise`<[`ITxBuilderComplete`](../interfaces/Core.ITxBuilderComplete.md)\>
+`Promise`<[`ITxBuilderTx`](../interfaces/Core.ITxBuilderTx.md)\>
 
 #### Defined in
 
@@ -67,7 +67,7 @@ ___
 
 ### buildSwapTx
 
-▸ `Abstract` **buildSwapTx**(`args`): `Promise`<[`ITxBuilderComplete`](../interfaces/Core.ITxBuilderComplete.md)\>
+▸ `Abstract` **buildSwapTx**(`args`): `Promise`<[`ITxBuilderTx`](../interfaces/Core.ITxBuilderTx.md)\>
 
 The main function to build a swap Transaction.
 
@@ -79,7 +79,7 @@ The main function to build a swap Transaction.
 
 #### Returns
 
-`Promise`<[`ITxBuilderComplete`](../interfaces/Core.ITxBuilderComplete.md)\>
+`Promise`<[`ITxBuilderTx`](../interfaces/Core.ITxBuilderTx.md)\>
 
 #### Defined in
 
@@ -89,7 +89,7 @@ ___
 
 ### buildWithdrawTx
 
-▸ `Abstract` **buildWithdrawTx**(`args`): `Promise`<[`ITxBuilderComplete`](../interfaces/Core.ITxBuilderComplete.md)\>
+▸ `Abstract` **buildWithdrawTx**(`args`): `Promise`<[`ITxBuilderTx`](../interfaces/Core.ITxBuilderTx.md)\>
 
 The main function to build a withdraw Transaction.
 
@@ -101,7 +101,7 @@ The main function to build a withdraw Transaction.
 
 #### Returns
 
-`Promise`<[`ITxBuilderComplete`](../interfaces/Core.ITxBuilderComplete.md)\>
+`Promise`<[`ITxBuilderTx`](../interfaces/Core.ITxBuilderTx.md)\>
 
 #### Defined in
 
@@ -111,7 +111,7 @@ ___
 
 ### buildZapTx
 
-▸ `Abstract` **buildZapTx**(`args`): `Promise`<[`ITxBuilderComplete`](../interfaces/Core.ITxBuilderComplete.md)\>
+▸ `Abstract` **buildZapTx**(`args`): `Promise`<[`ITxBuilderTx`](../interfaces/Core.ITxBuilderTx.md)\>
 
 The main function to build a zap Transaction.
 
@@ -123,11 +123,11 @@ The main function to build a zap Transaction.
 
 #### Returns
 
-`Promise`<[`ITxBuilderComplete`](../interfaces/Core.ITxBuilderComplete.md)\>
+`Promise`<[`ITxBuilderTx`](../interfaces/Core.ITxBuilderTx.md)\>
 
 #### Defined in
 
-[classes/Abstracts/TxBuilder.abstract.class.ts:82](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/classes/Abstracts/TxBuilder.abstract.class.ts#L82)
+[classes/Abstracts/TxBuilder.abstract.class.ts:80](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/classes/Abstracts/TxBuilder.abstract.class.ts#L80)
 
 ___
 
@@ -143,7 +143,7 @@ Helper function for child classes to easily grab the appropriate protocol parame
 
 #### Defined in
 
-[classes/Abstracts/TxBuilder.abstract.class.ts:88](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/classes/Abstracts/TxBuilder.abstract.class.ts#L88)
+[classes/Abstracts/TxBuilder.abstract.class.ts:86](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/classes/Abstracts/TxBuilder.abstract.class.ts#L86)
 
 ___
 

--- a/docs/typescript/core/classes/Extensions.TxBuilderLucid.md
+++ b/docs/typescript/core/classes/Extensions.TxBuilderLucid.md
@@ -49,7 +49,7 @@ TxBuilder&lt;
 
 #### Defined in
 
-[classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts:76](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts#L76)
+[classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts:81](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts#L81)
 
 ## Properties
 
@@ -65,7 +65,7 @@ TxBuilder.options
 
 #### Defined in
 
-[classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts:77](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts#L77)
+[classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts:82](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts#L82)
 
 ___
 
@@ -81,7 +81,7 @@ TxBuilder.query
 
 #### Defined in
 
-[classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts:78](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts#L78)
+[classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts:83](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts#L83)
 
 ## Methods
 
@@ -101,7 +101,7 @@ Helper function for child classes to easily grab the appropriate protocol parame
 
 #### Defined in
 
-[classes/Abstracts/TxBuilder.abstract.class.ts:88](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/classes/Abstracts/TxBuilder.abstract.class.ts#L88)
+[classes/Abstracts/TxBuilder.abstract.class.ts:86](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/classes/Abstracts/TxBuilder.abstract.class.ts#L86)
 
 ___
 
@@ -117,7 +117,7 @@ Initializes a Lucid instance with the
 
 #### Defined in
 
-[classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts:97](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts#L97)
+[classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts:102](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts#L102)
 
 ___
 
@@ -137,4 +137,4 @@ Returns a new Tx instance from Lucid. Throws an error if not ready.
 
 #### Defined in
 
-[classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts:127](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts#L127)
+[classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts:132](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts#L132)

--- a/docs/typescript/core/interfaces/Core.ITxBuilderBaseOptions.md
+++ b/docs/typescript/core/interfaces/Core.ITxBuilderBaseOptions.md
@@ -21,7 +21,7 @@ A supported Cardano network.
 
 #### Defined in
 
-[@types/txbuilder.ts:29](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/txbuilder.ts#L29)
+[@types/txbuilder.ts:50](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/txbuilder.ts#L50)
 
 ___
 
@@ -33,4 +33,4 @@ A CIP-30 compatible wallet.
 
 #### Defined in
 
-[@types/txbuilder.ts:27](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/txbuilder.ts#L27)
+[@types/txbuilder.ts:48](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/txbuilder.ts#L48)

--- a/docs/typescript/core/interfaces/Core.ITxBuilderComplete.md
+++ b/docs/typescript/core/interfaces/Core.ITxBuilderComplete.md
@@ -14,7 +14,19 @@ The CBOR encoded hex string of the transaction. Useful if you want to do somethi
 
 #### Defined in
 
-[@types/txbuilder.ts:16](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/txbuilder.ts#L16)
+[@types/txbuilder.ts:24](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/txbuilder.ts#L24)
+
+___
+
+### fees
+
+• **fees**: [`ITxBuilderFees`](Core.ITxBuilderFees.md)
+
+The calculated fees of the transaction.
+
+#### Defined in
+
+[@types/txbuilder.ts:26](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/txbuilder.ts#L26)
 
 ___
 
@@ -34,4 +46,4 @@ Submits the CBOR encoded transaction to the connected wallet returns a hex encod
 
 #### Defined in
 
-[@types/txbuilder.ts:18](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/txbuilder.ts#L18)
+[@types/txbuilder.ts:28](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/txbuilder.ts#L28)

--- a/docs/typescript/core/interfaces/Core.ITxBuilderFees.md
+++ b/docs/typescript/core/interfaces/Core.ITxBuilderFees.md
@@ -1,0 +1,5 @@
+# Interface: ITxBuilderFees
+
+[Core](../modules/Core.md).ITxBuilderFees
+
+The full list of calculated fees for a transaction built by a TxBuilder instance.

--- a/docs/typescript/core/interfaces/Core.ITxBuilderTx.md
+++ b/docs/typescript/core/interfaces/Core.ITxBuilderTx.md
@@ -1,0 +1,5 @@
+# Interface: ITxBuilderTx
+
+[Core](../modules/Core.md).ITxBuilderTx
+
+The primary top-level API surface for dealing with built TxBuilder transactions.

--- a/docs/typescript/core/interfaces/Extensions.ITxBuilderLucidOptions.md
+++ b/docs/typescript/core/interfaces/Extensions.ITxBuilderLucidOptions.md
@@ -27,7 +27,7 @@ The chosen provider options object to pass to Lucid.
 
 #### Defined in
 
-[classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts:39](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts#L39)
+[classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts:44](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts#L44)
 
 ___
 
@@ -43,7 +43,7 @@ A supported Cardano network.
 
 #### Defined in
 
-[@types/txbuilder.ts:29](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/txbuilder.ts#L29)
+[@types/txbuilder.ts:50](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/txbuilder.ts#L50)
 
 ___
 
@@ -55,7 +55,7 @@ The provider type used by Lucid. Currently only supports Blockfrost.
 
 #### Defined in
 
-[classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts:37](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts#L37)
+[classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts:42](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts#L42)
 
 ___
 
@@ -71,4 +71,4 @@ A CIP-30 compatible wallet.
 
 #### Defined in
 
-[@types/txbuilder.ts:27](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/txbuilder.ts#L27)
+[@types/txbuilder.ts:48](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/txbuilder.ts#L48)

--- a/docs/typescript/core/modules/Core.md
+++ b/docs/typescript/core/modules/Core.md
@@ -86,6 +86,8 @@ const txHash = await sdk.swap( /** ... */ ).then(({ submit }) => submit());
 - [ISwapArgs](../interfaces/Core.ISwapArgs.md)
 - [ITxBuilderBaseOptions](../interfaces/Core.ITxBuilderBaseOptions.md)
 - [ITxBuilderComplete](../interfaces/Core.ITxBuilderComplete.md)
+- [ITxBuilderFees](../interfaces/Core.ITxBuilderFees.md)
+- [ITxBuilderTx](../interfaces/Core.ITxBuilderTx.md)
 - [IWithdrawArgs](../interfaces/Core.IWithdrawArgs.md)
 - [IZapArgs](../interfaces/Core.IZapArgs.md)
 - [OrderConfigArgs](../interfaces/Core.OrderConfigArgs.md)

--- a/packages/core/src/@types/txbuilder.ts
+++ b/packages/core/src/@types/txbuilder.ts
@@ -9,13 +9,34 @@ import {
 import { AssetAmount } from "../classes/AssetAmount.class";
 
 /**
+ * The primary top-level API surface for dealing with built TxBuilder transactions.
+ */
+export interface ITxBuilderTx {
+  sign: () => ITxBuilderTx;
+  complete: () => Promise<ITxBuilderComplete>;
+}
+
+/**
  * The returned interface once a transaction is successfully built.
  */
 export interface ITxBuilderComplete {
   /** The CBOR encoded hex string of the transaction. Useful if you want to do something with it instead of submitting to the wallet. */
   cbor: string;
+  /** The calculated fees of the transaction. */
+  fees: ITxBuilderFees;
   /** Submits the CBOR encoded transaction to the connected wallet returns a hex encoded transaction hash. */
   submit: () => Promise<string>;
+}
+
+/**
+ * The full list of calculated fees for a transaction built by a TxBuilder instance.
+ */
+export interface ITxBuilderFees {
+  cardanoTxFee: AssetAmount;
+  deposit: AssetAmount;
+  scooperFee: AssetAmount;
+  liquidity?: AssetAmount;
+  referral?: AssetAmount;
 }
 
 /**

--- a/packages/core/src/classes/Abstracts/TxBuilder.abstract.class.ts
+++ b/packages/core/src/classes/Abstracts/TxBuilder.abstract.class.ts
@@ -1,6 +1,6 @@
 import {
   IQueryProviderClass,
-  ITxBuilderComplete,
+  ITxBuilderTx,
   ITxBuilderBaseOptions,
   IZapArgs,
   SwapConfigArgs,
@@ -47,39 +47,37 @@ export abstract class TxBuilder<
    * The main function to build a swap Transaction.
    *
    * @param args The built SwapArguments from a {@link Core.SwapConfig} instance.
-   * @returns {ITxBuilderComplete}
+   * @returns {ITxBuilderTx}
    */
-  abstract buildSwapTx(args: SwapConfigArgs): Promise<ITxBuilderComplete>;
+  abstract buildSwapTx(args: SwapConfigArgs): Promise<ITxBuilderTx>;
 
   /**
    * The main function to build a deposit Transaction.
    *
    * @param args The built DepositArguments from a {@link Core.DepositConfig} instance.
    */
-  abstract buildDepositTx(args: DepositConfigArgs): Promise<ITxBuilderComplete>;
+  abstract buildDepositTx(args: DepositConfigArgs): Promise<ITxBuilderTx>;
 
   /**
    * The main function to build a withdraw Transaction.
    *
    * @param args The built WithdrawArguments from a {@link Core.WithdrawConfig} instance.
    */
-  abstract buildWithdrawTx(
-    args: WithdrawConfigArgs
-  ): Promise<ITxBuilderComplete>;
+  abstract buildWithdrawTx(args: WithdrawConfigArgs): Promise<ITxBuilderTx>;
 
   /**
    * The main function to build a cancellation Transaction.
    *
    * @param args The built CancelArguments from a {@link Core.CancelConfig} instance.
    */
-  abstract buildCancelTx(args: CancelConfigArgs): Promise<ITxBuilderComplete>;
+  abstract buildCancelTx(args: CancelConfigArgs): Promise<ITxBuilderTx>;
 
   /**
    * The main function to build a zap Transaction.
    *
    * @param args The built ZapArguments from a {@link Core.ZapConfig} instance.
    */
-  abstract buildZapTx(args: IZapArgs): Promise<ITxBuilderComplete>;
+  abstract buildZapTx(args: IZapArgs): Promise<ITxBuilderTx>;
 
   /**
    * Helper function for child classes to easily grab the appropriate protocol parameters for SundaeSwap.

--- a/packages/core/src/lib/constants.ts
+++ b/packages/core/src/lib/constants.ts
@@ -8,3 +8,4 @@ export const MIN_ASSET_LENGTH = 56;
  * The AssetID for the Cardano native token, $ADA.
  */
 export const ADA_ASSET_ID = "";
+export const ADA_ASSET_DECIMAL = 6;

--- a/packages/demo/src/components/Actions/Actions.tsx
+++ b/packages/demo/src/components/Actions/Actions.tsx
@@ -1,5 +1,10 @@
-import { IPoolQuery, OrderAddresses } from "@sundaeswap/sdk-core";
+import {
+  IPoolQuery,
+  ITxBuilderFees,
+  OrderAddresses,
+} from "@sundaeswap/sdk-core";
 import { Dispatch, FC, SetStateAction, useState } from "react";
+import ReactJson from "react-json-view";
 import { useAppState } from "../../state/context";
 import { Deposit } from "./modules/Deposit";
 import { SwapAB } from "./modules/SwapAB";
@@ -30,6 +35,7 @@ interface CBOR {
 export interface ActionArgs {
   submit?: boolean;
   setCBOR: Dispatch<SetStateAction<CBOR>>;
+  setFees: Dispatch<SetStateAction<ITxBuilderFees | undefined>>;
 }
 
 export const Actions: FC = () => {
@@ -37,32 +43,33 @@ export const Actions: FC = () => {
   const [cbor, setCBOR] = useState<CBOR>({
     cbor: "",
   });
+  const [fees, setFees] = useState<ITxBuilderFees>();
   const [submit, setSubmit] = useState(false);
 
   if (!SDK) {
     return null;
   }
 
-  const tempCancelOrder = async () => {
-    const utxo = {
-      hash: "3f8ffa9fe490b43bd286e73a7c62e951c3b1c6729a65751d87fce9faba4f8cd6",
-      index: 0,
-    };
+  // const tempCancelOrder = async () => {
+  //   const utxo = {
+  //     hash: "3f8ffa9fe490b43bd286e73a7c62e951c3b1c6729a65751d87fce9faba4f8cd6",
+  //     index: 0,
+  //   };
 
-    const { datum, datumHash } = await SDK.query().findOpenOrderDatum(utxo);
+  //   const { datum, datumHash } = await SDK.query().findOpenOrderDatum(utxo);
 
-    if (datum) {
-      const hash = await SDK.cancel({
-        datum,
-        datumHash,
-        utxo,
-        address:
-          "addr_test1qz5ykwgmrejk3mdw0u3cewqx375qkjwnv5n4mhgjwap4n4qdxw2hcpavmh0vexyzg476ytc9urgcnalujkcewtnd2yzsemxyd6",
-      });
+  //   if (datum) {
+  //     const hash = await SDK.cancel({
+  //       datum,
+  //       datumHash,
+  //       utxo,
+  //       address:
+  //         "addr_test1qz5ykwgmrejk3mdw0u3cewqx375qkjwnv5n4mhgjwap4n4qdxw2hcpavmh0vexyzg476ytc9urgcnalujkcewtnd2yzsemxyd6",
+  //     });
 
-      console.log(hash);
-    }
-  };
+  //     console.log(hash);
+  //   }
+  // };
 
   return (
     <div className="flex flex-col gap-4">
@@ -79,10 +86,10 @@ export const Actions: FC = () => {
         </div>
       </h2>
       <div className="grid grid-cols-2 gap-4">
-        <SwapAB setCBOR={setCBOR} submit={submit} />
-        <SwapBA setCBOR={setCBOR} submit={submit} />
-        <Deposit setCBOR={setCBOR} submit={submit} />
-        <Withdraw setCBOR={setCBOR} submit={submit} />
+        <SwapAB setFees={setFees} setCBOR={setCBOR} submit={submit} />
+        <SwapBA setFees={setFees} setCBOR={setCBOR} submit={submit} />
+        <Deposit setFees={setFees} setCBOR={setCBOR} submit={submit} />
+        <Withdraw setFees={setFees} setCBOR={setCBOR} submit={submit} />
         {/* <button onClick={tempCancelOrder}>Cancel Order</button> */}
         {/* <Zap setCBOR={setCBOR} submit={submit} /> */}
       </div>
@@ -97,6 +104,25 @@ export const Actions: FC = () => {
       <h2 className="mb-4 text-lg font-bold text-white">CBOR</h2>
       <div className="p-8 rounded-lg bg-gray-800 border-gray-700 whitespace-pre-wrap break-all">
         {cbor.cbor}
+      </div>
+      <h2 className="mb-4 text-lg font-bold text-white">Fees</h2>
+      <div className="p-8 rounded-lg bg-gray-800 border-gray-700 whitespace-pre-wrap break-all">
+        {fees && (
+          <ReactJson
+            theme="embers"
+            enableClipboard={false}
+            style={{
+              padding: 8,
+              borderRadius: 8,
+              border: "1px solid #555",
+            }}
+            src={{
+              cardanoTxFee: fees.cardanoTxFee.getAmount().toString(),
+              scooperFee: fees.scooperFee.getAmount().toString(),
+              deposit: fees.deposit.getAmount().toString(),
+            }}
+          />
+        )}
       </div>
     </div>
   );

--- a/packages/demo/src/components/Actions/modules/Deposit.tsx
+++ b/packages/demo/src/components/Actions/modules/Deposit.tsx
@@ -4,7 +4,7 @@ import { useAppState } from "../../../state/context";
 import { ActionArgs, defaultOrderAddresses, poolQuery } from "../Actions";
 import Button from "../../Button";
 
-export const Deposit: FC<ActionArgs> = ({ setCBOR, submit }) => {
+export const Deposit: FC<ActionArgs> = ({ setCBOR, setFees, submit }) => {
   const { SDK } = useAppState();
   const [depositing, setDepositing] = useState(false);
 
@@ -35,14 +35,17 @@ export const Deposit: FC<ActionArgs> = ({ setCBOR, submit }) => {
         ],
       }).then(async (res) => {
         if (submit) {
-          const hash = await res.submit();
+          const { cbor, submit, fees } = await res.sign().complete();
+          setFees(fees);
           setCBOR({
-            cbor: res.cbor,
-            hash,
+            cbor,
+            hash: await submit(),
           });
         } else {
+          const { cbor, fees } = await res.complete();
+          setFees(fees);
           setCBOR({
-            cbor: res.cbor,
+            cbor,
           });
         }
       });

--- a/packages/demo/src/components/Actions/modules/SwapAB.tsx
+++ b/packages/demo/src/components/Actions/modules/SwapAB.tsx
@@ -4,7 +4,7 @@ import { useAppState } from "../../../state/context";
 import { ActionArgs, defaultOrderAddresses, poolQuery } from "../Actions";
 import Button from "../../Button";
 
-export const SwapAB: FC<ActionArgs> = ({ setCBOR, submit }) => {
+export const SwapAB: FC<ActionArgs> = ({ setCBOR, setFees, submit }) => {
   const { SDK } = useAppState();
   const [reverseSwapping, setReverseSwapping] = useState(false);
 
@@ -25,14 +25,17 @@ export const SwapAB: FC<ActionArgs> = ({ setCBOR, submit }) => {
         },
       }).then(async (res) => {
         if (submit) {
-          const hash = await res.submit();
+          const { cbor, submit, fees } = await res.sign().complete();
+          setFees(fees);
           setCBOR({
-            cbor: res.cbor,
-            hash,
+            cbor,
+            hash: await submit(),
           });
         } else {
+          const { cbor, fees } = await res.complete();
+          setFees(fees);
           setCBOR({
-            cbor: res.cbor,
+            cbor,
           });
         }
       });

--- a/packages/demo/src/components/Actions/modules/SwapBA.tsx
+++ b/packages/demo/src/components/Actions/modules/SwapBA.tsx
@@ -4,7 +4,7 @@ import { useAppState } from "../../../state/context";
 import { ActionArgs, defaultOrderAddresses, poolQuery } from "../Actions";
 import Button from "../../Button";
 
-export const SwapBA: FC<ActionArgs> = ({ setCBOR, submit }) => {
+export const SwapBA: FC<ActionArgs> = ({ setCBOR, setFees, submit }) => {
   const { SDK } = useAppState();
   const [swapping, setSwapping] = useState(false);
 
@@ -26,14 +26,17 @@ export const SwapBA: FC<ActionArgs> = ({ setCBOR, submit }) => {
         },
       }).then(async (res) => {
         if (submit) {
-          const hash = await res.submit();
+          const { cbor, submit, fees } = await res.sign().complete();
+          setFees(fees);
           setCBOR({
-            cbor: res.cbor,
-            hash,
+            cbor,
+            hash: await submit(),
           });
         } else {
+          const { cbor, fees } = await res.complete();
+          setFees(fees);
           setCBOR({
-            cbor: res.cbor,
+            cbor,
           });
         }
       });

--- a/packages/demo/src/components/Actions/modules/Withdraw.tsx
+++ b/packages/demo/src/components/Actions/modules/Withdraw.tsx
@@ -6,7 +6,7 @@ import { ActionArgs, defaultOrderAddresses, poolQuery } from "../Actions";
 import Button from "../../Button";
 import type { Lucid } from "lucid-cardano";
 
-export const Withdraw: FC<ActionArgs> = ({ setCBOR, submit }) => {
+export const Withdraw: FC<ActionArgs> = ({ setCBOR, setFees, submit }) => {
   const { SDK } = useAppState();
   const [withdrawing, setWithdrawing] = useState(false);
 
@@ -43,14 +43,17 @@ export const Withdraw: FC<ActionArgs> = ({ setCBOR, submit }) => {
         },
       }).then(async (res) => {
         if (submit) {
-          const hash = await res.submit();
+          const { cbor, submit, fees } = await res.sign().complete();
+          setFees(fees);
           setCBOR({
-            cbor: res.cbor,
-            hash,
+            cbor,
+            hash: await submit(),
           });
         } else {
+          const { cbor, fees } = await res.complete();
+          setFees(fees);
           setCBOR({
-            cbor: res.cbor,
+            cbor,
           });
         }
       });

--- a/packages/demo/src/components/Actions/modules/Zap.tsx
+++ b/packages/demo/src/components/Actions/modules/Zap.tsx
@@ -4,7 +4,7 @@ import { useAppState } from "../../../state/context";
 import { ActionArgs, defaultOrderAddresses, poolQuery } from "../Actions";
 import Button from "../../Button";
 
-export const Zap: FC<ActionArgs> = ({ setCBOR, submit }) => {
+export const Zap: FC<ActionArgs> = ({ setCBOR, setFees, submit }) => {
   const { SDK } = useAppState();
   const [zapping, setZapping] = useState(false);
 
@@ -26,14 +26,17 @@ export const Zap: FC<ActionArgs> = ({ setCBOR, submit }) => {
         },
       }).then(async (res) => {
         if (submit) {
-          const hash = await res.submit();
+          const { cbor, submit, fees } = await res.sign().complete();
+          setFees(fees);
           setCBOR({
-            cbor: res.cbor,
-            hash,
+            cbor,
+            hash: await submit(),
           });
         } else {
+          const { cbor, fees } = await res.complete();
+          setFees(fees);
           setCBOR({
-            cbor: res.cbor,
+            cbor,
           });
         }
       });


### PR DESCRIPTION
This process adds the ability to generate CBOR without signatures attached.

For example:

```ts
const tx = await SDK.swap(/* args... */).then(res => {
  const { fees } = await res.complete();
  const { cbor, submit } = await res.sign().complete();
  
  console.log(cbor);
  const txHash = await submit();
});