### PR TITLE
fix: complete API

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": true,
   "useWorkspaces": true,
-  "version": "0.2.0-alpha.34",
+  "version": "1.0.0-alpha",
   "npmClient": "yarn",
   "ignoreChanges": [
     "**/__tests__/**",

--- a/packages/core/src/@types/txbuilder.ts
+++ b/packages/core/src/@types/txbuilder.ts
@@ -8,8 +8,8 @@ export interface ITxBuilderTx<T = unknown, K = unknown> {
   tx: T;
   fees: ITxBuilderFees;
   datum: K;
-  sign: () => ITxBuilderTx;
-  complete: () => Promise<ITxBuilderComplete>;
+  sign: () => Promise<ITxBuilderComplete>;
+  build: () => Promise<ITxBuilderComplete>;
 }
 
 /**

--- a/packages/core/src/classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts
+++ b/packages/core/src/classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts
@@ -568,15 +568,7 @@ export class TxBuilderLucid extends TxBuilder<
           ADA_ASSET_DECIMAL
         ),
       },
-      async complete() {
-        if (sign) {
-          const signedTx = await finishedTx.sign().complete();
-          return {
-            submit: async () => await signedTx.submit(),
-            cbor: Buffer.from(signedTx.txSigned.to_bytes()).toString("hex"),
-          };
-        }
-
+      async build() {
         return {
           submit: async () => {
             throw new Error(
@@ -586,9 +578,12 @@ export class TxBuilderLucid extends TxBuilder<
           cbor: Buffer.from(finishedTx.txComplete.to_bytes()).toString("hex"),
         };
       },
-      sign() {
-        sign = true;
-        return thisTx;
+      async sign() {
+        const signedTx = await finishedTx.sign().complete();
+        return {
+          submit: async () => await signedTx.submit(),
+          cbor: Buffer.from(signedTx.txSigned.to_bytes()).toString("hex"),
+        };
       },
     };
 

--- a/packages/demo/src/components/Actions/modules/Deposit.tsx
+++ b/packages/demo/src/components/Actions/modules/Deposit.tsx
@@ -34,16 +34,16 @@ export const Deposit: FC<ActionArgs> = ({ setCBOR, setFees, submit }) => {
             decimals: 6,
           }),
         ],
-      }).then(async ({ sign, fees, complete }) => {
+      }).then(async ({ sign, build, fees }) => {
         setFees(fees);
         if (submit) {
-          const { cbor, submit } = await sign().complete();
+          const { cbor, submit } = await sign();
           setCBOR({
             cbor,
             hash: await submit(),
           });
         } else {
-          const { cbor } = await complete();
+          const { cbor } = await build();
           setCBOR({
             cbor,
           });

--- a/packages/demo/src/components/Actions/modules/LockAssets.tsx
+++ b/packages/demo/src/components/Actions/modules/LockAssets.tsx
@@ -32,17 +32,16 @@ export const Lock: FC<ActionArgs> = ({ setCBOR, setFees, submit }) => {
         ownerAddress: walletAddress,
         lockedValues: [new AssetAmount(5000000n, { assetId: "", decimals: 6 })],
         delegation: delegations,
-      }).then(async ({ sign, fees, complete }) => {
+      }).then(async ({ sign, build, fees }) => {
         setFees(fees);
         if (submit) {
-          console.log("submitted");
-          const { cbor, submit } = await sign().complete();
+          const { cbor, submit } = await sign();
           setCBOR({
             cbor,
             hash: await submit(),
           });
         } else {
-          const { cbor } = await complete();
+          const { cbor } = await build();
           setCBOR({
             cbor,
           });

--- a/packages/demo/src/components/Actions/modules/SwapAB.tsx
+++ b/packages/demo/src/components/Actions/modules/SwapAB.tsx
@@ -25,16 +25,16 @@ export const SwapAB: FC<ActionArgs> = ({ setCBOR, setFees, submit }) => {
           },
         },
         suppliedAsset: new AssetAmount(25000000n, { assetId: "", decimals: 6 }),
-      }).then(async ({ fees, sign, complete }) => {
+      }).then(async ({ sign, build, fees }) => {
         setFees(fees);
         if (submit) {
-          const { cbor, submit } = await sign().complete();
+          const { cbor, submit } = await sign();
           setCBOR({
             cbor,
             hash: await submit(),
           });
         } else {
-          const { cbor } = await complete();
+          const { cbor } = await build();
           setCBOR({
             cbor,
           });

--- a/packages/demo/src/components/Actions/modules/SwapBA.tsx
+++ b/packages/demo/src/components/Actions/modules/SwapBA.tsx
@@ -28,16 +28,16 @@ export const SwapBA: FC<ActionArgs> = ({ setCBOR, setFees, submit }) => {
             "fa3eff2047fdf9293c5feef4dc85ce58097ea1c6da4845a351535183.74494e4459",
           decimals: 6,
         }),
-      }).then(async ({ fees, sign, complete }) => {
+      }).then(async ({ sign, build, fees }) => {
         setFees(fees);
         if (submit) {
-          const { cbor, submit } = await sign().complete();
+          const { cbor, submit } = await sign();
           setCBOR({
             cbor,
             hash: await submit(),
           });
         } else {
-          const { cbor } = await complete();
+          const { cbor } = await build();
           setCBOR({
             cbor,
           });

--- a/packages/demo/src/components/Actions/modules/UnlockAssets.tsx
+++ b/packages/demo/src/components/Actions/modules/UnlockAssets.tsx
@@ -23,16 +23,16 @@ export const Unlock: FC<ActionArgs> = ({ setCBOR, setFees, submit }) => {
             index: 0,
           },
         ],
-      }).then(async ({ sign, fees, complete }) => {
+      }).then(async ({ sign, build, fees }) => {
         setFees(fees);
         if (submit) {
-          const { cbor, submit } = await sign().complete();
+          const { cbor, submit } = await sign();
           setCBOR({
             cbor,
             hash: await submit(),
           });
         } else {
-          const { cbor } = await complete();
+          const { cbor } = await build();
           setCBOR({
             cbor,
           });

--- a/packages/demo/src/components/Actions/modules/UpdateSwap.tsx
+++ b/packages/demo/src/components/Actions/modules/UpdateSwap.tsx
@@ -53,16 +53,16 @@ export const UpdateSwap: FC<ActionArgs> = ({ setCBOR, setFees, submit }) => {
       };
 
       await SDK.updateSwap(cancelConfig, updatedSwapConfig).then(
-        async ({ fees, sign, complete }) => {
+        async ({ sign, build, fees }) => {
           setFees(fees);
           if (submit) {
-            const { cbor, submit } = await sign().complete();
+            const { cbor, submit } = await sign();
             setCBOR({
               cbor,
               hash: await submit(),
             });
           } else {
-            const { cbor } = await complete();
+            const { cbor } = await build();
             setCBOR({
               cbor,
             });

--- a/packages/demo/src/components/Actions/modules/Withdraw.tsx
+++ b/packages/demo/src/components/Actions/modules/Withdraw.tsx
@@ -45,16 +45,16 @@ export const Withdraw: FC<ActionArgs> = ({ setCBOR, setFees, submit }) => {
             "4086577ed57c514f8e29b78f42ef4f379363355a3b65b9a032ee30c9.6c702002",
           decimals: 6,
         }),
-      }).then(async ({ fees, sign, complete }) => {
+      }).then(async ({ sign, build, fees }) => {
         setFees(fees);
         if (submit) {
-          const { cbor, submit } = await sign().complete();
+          const { cbor, submit } = await sign();
           setCBOR({
             cbor,
             hash: await submit(),
           });
         } else {
-          const { cbor } = await complete();
+          const { cbor } = await build();
           setCBOR({
             cbor,
           });

--- a/packages/demo/src/components/Actions/modules/Zap.tsx
+++ b/packages/demo/src/components/Actions/modules/Zap.tsx
@@ -26,16 +26,16 @@ export const Zap: FC<ActionArgs> = ({ setCBOR, setFees, submit }) => {
           },
         },
         swapSlippage: 0.3,
-      }).then(async ({ fees, sign, complete }) => {
+      }).then(async ({ sign, build, fees }) => {
         setFees(fees);
         if (submit) {
-          const { cbor, submit } = await sign().complete();
+          const { cbor, submit } = await sign();
           setCBOR({
             cbor,
             hash: await submit(),
           });
         } else {
-          const { cbor } = await complete();
+          const { cbor } = await build();
           setCBOR({
             cbor,
           });

--- a/packages/demo/src/components/SettingsViewer/SettingsViewer.tsx
+++ b/packages/demo/src/components/SettingsViewer/SettingsViewer.tsx
@@ -1,7 +1,8 @@
 import { FC } from "react";
 import ReactJson from "react-json-view";
-import { useAppState } from "../../state/context";
 import { ITxBuilderBaseOptions } from "@sundaeswap/sdk-core";
+
+import { useAppState } from "../../state/context";
 
 const SettingsViewer: FC = () => {
   const { SDK } = useAppState();


### PR DESCRIPTION
The API was doing a double request in that the  variable, if previously set to , would not reset when just building later. This update makes it more obvious with a  and  method that handles these scenarios separately.