### PR TITLE
fix: deposit amount on withdraw

### DIFF
--- a/packages/core/src/classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts
+++ b/packages/core/src/classes/Extensions/TxBuilders/TxBuilder.Lucid.class.ts
@@ -453,7 +453,6 @@ export class TxBuilderLucid extends TxBuilder<
     return this.completeTx({
       tx,
       datum: cbor,
-      deposit: 0n,
       referralFee: referralFee?.payment,
     });
   }


### PR DESCRIPTION
The deposit amount for withdrawing tokens was set to `0`. Since we are sending LP tokens to validate the withdraw, we attach a deposit (or rider fee) to to the tx.