### PR TITLE
SB-1125

### DIFF
--- a/docs/typescript/taste-test/classes/TasteTest.md
+++ b/docs/typescript/taste-test/classes/TasteTest.md
@@ -37,6 +37,28 @@ An instance of the Lucid class, providing various utility methods for blockchain
 
 ## Methods
 
+### \_getTasteTestTypeFromArgs
+
+▸ `Private` **_getTasteTestTypeFromArgs**(`args`): [`IBaseArgs`](../interfaces/IBaseArgs.md) & { `tasteTestType`: [`TTasteTestType`](../modules.md#ttastetesttype)  }
+
+A utility method to default the Taste Test type to liquidity if not set.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `args` | [`IBaseArgs`](../interfaces/IBaseArgs.md) | The base arguments. |
+
+#### Returns
+
+[`IBaseArgs`](../interfaces/IBaseArgs.md) & { `tasteTestType`: [`TTasteTestType`](../modules.md#ttastetesttype)  }
+
+#### Defined in
+
+[taste-test/src/lib/classes/TasteTest.class.ts:703](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.class.ts#L703)
+
+___
+
 ### completeTx
 
 ▸ `Private` **completeTx**(`params`): `Promise`<[`ITxBuilder`](../interfaces/ITxBuilder.md)<`Tx`, `undefined` \| `string`\>\>
@@ -74,7 +96,7 @@ Throws an error if the transaction cannot be completed or if there are issues wi
 
 #### Defined in
 
-[taste-test/src/lib/classes/TasteTest.class.ts:473](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.class.ts#L473)
+[taste-test/src/lib/classes/TasteTest.class.ts:545](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.class.ts#L545)
 
 ___
 
@@ -121,7 +143,7 @@ which includes the transaction, its associated fees, and functions to build, sig
 
 #### Defined in
 
-[taste-test/src/lib/classes/TasteTest.class.ts:113](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.class.ts#L113)
+[taste-test/src/lib/classes/TasteTest.class.ts:116](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.class.ts#L116)
 
 ___
 
@@ -152,7 +174,7 @@ Will throw an error if unable to derive UTXO from the provided OutRef in `script
 
 #### Defined in
 
-[taste-test/src/lib/classes/TasteTest.class.ts:576](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.class.ts#L576)
+[taste-test/src/lib/classes/TasteTest.class.ts:648](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.class.ts#L648)
 
 ___
 
@@ -183,7 +205,7 @@ Will throw an error if unable to derive UTXO from the provided OutRef in `script
 
 #### Defined in
 
-[taste-test/src/lib/classes/TasteTest.class.ts:541](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.class.ts#L541)
+[taste-test/src/lib/classes/TasteTest.class.ts:613](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.class.ts#L613)
 
 ___
 
@@ -210,7 +232,7 @@ If neither stake nor payment credentials could be determined from the address.
 
 #### Defined in
 
-[taste-test/src/lib/classes/TasteTest.class.ts:611](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.class.ts#L611)
+[taste-test/src/lib/classes/TasteTest.class.ts:683](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.class.ts#L683)
 
 ___
 
@@ -257,7 +279,7 @@ equipped with the transaction, its associated fees, and functions to build, sign
 
 #### Defined in
 
-[taste-test/src/lib/classes/TasteTest.class.ts:243](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.class.ts#L243)
+[taste-test/src/lib/classes/TasteTest.class.ts:283](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.class.ts#L283)
 
 ___
 
@@ -303,4 +325,4 @@ Throws errors if the withdrawal conditions are not met, such as missing keys, in
 
 #### Defined in
 
-[taste-test/src/lib/classes/TasteTest.class.ts:315](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.class.ts#L315)
+[taste-test/src/lib/classes/TasteTest.class.ts:359](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.class.ts#L359)

--- a/docs/typescript/taste-test/classes/TasteTest.md
+++ b/docs/typescript/taste-test/classes/TasteTest.md
@@ -39,7 +39,7 @@ An instance of the Lucid class, providing various utility methods for blockchain
 
 ### \_getTasteTestTypeFromArgs
 
-▸ `Private` **_getTasteTestTypeFromArgs**(`args`): [`IBaseArgs`](../interfaces/IBaseArgs.md) & { `tasteTestType`: [`TTasteTestType`](../modules.md#ttastetesttype)  }
+▸ `Private` **_getTasteTestTypeFromArgs**(`args`): [`TTasteTestType`](../modules.md#ttastetesttype)
 
 A utility method to default the Taste Test type to liquidity if not set.
 
@@ -51,7 +51,7 @@ A utility method to default the Taste Test type to liquidity if not set.
 
 #### Returns
 
-[`IBaseArgs`](../interfaces/IBaseArgs.md) & { `tasteTestType`: [`TTasteTestType`](../modules.md#ttastetesttype)  }
+[`TTasteTestType`](../modules.md#ttastetesttype)
 
 #### Defined in
 

--- a/docs/typescript/taste-test/modules.md
+++ b/docs/typescript/taste-test/modules.md
@@ -68,3 +68,16 @@ tt?.deposit({ ...args });
 - [ITxBuilder](interfaces/ITxBuilder.md)
 - [IUpdateArgs](interfaces/IUpdateArgs.md)
 - [IWithdrawArgs](interfaces/IWithdrawArgs.md)
+
+## Type Aliases
+
+### TTasteTestType
+
+Ƭ **TTasteTestType**: ``"basic"`` \| ``"liquidity"``
+
+The type of Taste Test, where "basic" is a non-pool Taste Test, and "liquidity"
+is ends the taste test with pool creation.
+
+#### Defined in
+
+[taste-test/src/@types/index.ts:14](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/@types/index.ts#L14)

--- a/packages/taste-test/src/@types/contracts.ts
+++ b/packages/taste-test/src/@types/contracts.ts
@@ -53,12 +53,41 @@ export type NodeKeySchema = Data.Static<typeof NodeKeySchema>;
 export type NodeKey = Data.Static<typeof NodeKeySchema>;
 export const NodeKey = NodeKeySchema as unknown as NodeKey;
 
+export const LiquiditySetNodeSchema = Data.Object({
+  key: NodeKeySchema,
+  next: NodeKeySchema,
+  commitment: Data.Integer(),
+});
+export type LiquiditySetNode = Data.Static<typeof LiquiditySetNodeSchema>;
+export const LiquiditySetNode =
+  LiquiditySetNodeSchema as unknown as LiquiditySetNode;
+
 export const SetNodeSchema = Data.Object({
   key: NodeKeySchema,
   next: NodeKeySchema,
 });
 export type SetNode = Data.Static<typeof SetNodeSchema>;
 export const SetNode = SetNodeSchema as unknown as SetNode;
+
+export const LiquidityNodeActionSchema = Data.Enum([
+  Data.Literal("PLInit"),
+  Data.Literal("PLDInit"),
+  Data.Object({
+    PInsert: Data.Object({
+      keyToInsert: PubKeyHashSchema,
+      coveringNode: LiquiditySetNodeSchema,
+    }),
+  }),
+  Data.Object({
+    PRemove: Data.Object({
+      keyToRemove: PubKeyHashSchema,
+      coveringNode: LiquiditySetNodeSchema,
+    }),
+  }),
+]);
+export type LiquidityNodeAction = Data.Static<typeof LiquidityNodeActionSchema>;
+export const LiquidityNodeAction =
+  LiquidityNodeActionSchema as unknown as LiquidityNodeAction;
 
 export const DiscoveryNodeActionSchema = Data.Enum([
   Data.Literal("PInit"),

--- a/packages/taste-test/src/@types/index.ts
+++ b/packages/taste-test/src/@types/index.ts
@@ -8,6 +8,12 @@ import type {
 } from "lucid-cardano";
 
 /**
+ * The type of Taste Test, where "basic" is a non-pool Taste Test, and "liquidity"
+ * is ends the taste test with pool creation.
+ */
+export type TTasteTestType = "basic" | "liquidity";
+
+/**
  * Common arguments for the deposit and update methods of the TasteTest class instance.
  */
 export interface IBaseArgs {
@@ -17,6 +23,7 @@ export interface IBaseArgs {
     policy: MintingPolicy | OutRef;
     validator: SpendingValidator | OutRef;
   };
+  tasteTestType?: TTasteTestType;
   utxos?: UTxO[];
 }
 

--- a/packages/taste-test/src/lib/classes/TasteTest.class.ts
+++ b/packages/taste-test/src/lib/classes/TasteTest.class.ts
@@ -23,9 +23,12 @@ import {
   IDepositArgs,
   IUpdateArgs,
   IWithdrawArgs,
+  TTasteTestType,
 } from "../../@types";
 import {
   DiscoveryNodeAction,
+  LiquidityNodeAction,
+  LiquiditySetNode,
   NodeValidatorAction,
   SetNode,
 } from "../../@types/contracts";
@@ -126,6 +129,8 @@ export class TasteTest implements AbstractTasteTest {
       );
     }
 
+    const isLiquidityTasteTest =
+      this._getTasteTestTypeFromArgs(args).tasteTestType === "liquidity";
     const nodeValidator = await this.getNodeValidatorFromArgs(args);
     const nodeValidatorAddr =
       this.lucid.utils.validatorToAddress(nodeValidator);
@@ -140,11 +145,19 @@ export class TasteTest implements AbstractTasteTest {
     if (args.utxos) {
       coveringNode = args.utxos[0];
     } else {
-      coveringNode = findCoveringNode(nodeUTXOs, userKey);
+      coveringNode = findCoveringNode(
+        nodeUTXOs,
+        userKey,
+        this._getTasteTestTypeFromArgs(args).tasteTestType
+      );
     }
 
     if (!coveringNode || !coveringNode.datum) {
-      const hasOwnNode = findOwnNode(nodeUTXOs, userKey);
+      const hasOwnNode = findOwnNode(
+        nodeUTXOs,
+        userKey,
+        this._getTasteTestTypeFromArgs(args).tasteTestType
+      );
       if (hasOwnNode && updateFallback) {
         return this.update({ ...args });
       }
@@ -152,23 +165,50 @@ export class TasteTest implements AbstractTasteTest {
       throw new Error("Could not find covering node.");
     }
 
-    const coveringNodeDatum = Data.from(coveringNode.datum, SetNode);
-
-    const prevNodeDatum = Data.to(
-      {
-        key: coveringNodeDatum.key,
-        next: userKey,
-      },
-      SetNode
+    const coveringNodeDatum = Data.from(
+      coveringNode.datum,
+      isLiquidityTasteTest ? LiquiditySetNode : SetNode
     );
 
-    const nodeDatum = Data.to(
-      {
-        key: userKey,
-        next: coveringNodeDatum.next,
-      },
-      SetNode
-    );
+    let prevNodeDatum: string = "";
+    if (isLiquidityTasteTest) {
+      prevNodeDatum = Data.to(
+        {
+          key: coveringNodeDatum.key,
+          next: userKey,
+          commitment: BigInt(0),
+        },
+        LiquiditySetNode
+      );
+    } else {
+      prevNodeDatum = Data.to(
+        {
+          key: coveringNodeDatum.key,
+          next: userKey,
+        },
+        SetNode
+      );
+    }
+
+    let nodeDatum: string = "";
+    if (isLiquidityTasteTest) {
+      nodeDatum = Data.to(
+        {
+          key: userKey,
+          next: coveringNodeDatum.next,
+          commitment: BigInt(0),
+        },
+        LiquiditySetNode
+      );
+    } else {
+      nodeDatum = Data.to(
+        {
+          key: userKey,
+          next: coveringNodeDatum.next,
+        },
+        SetNode
+      );
+    }
 
     const redeemerNodePolicy = Data.to(
       {
@@ -177,7 +217,7 @@ export class TasteTest implements AbstractTasteTest {
           coveringNode: coveringNodeDatum,
         },
       },
-      DiscoveryNodeAction
+      isLiquidityTasteTest ? LiquidityNodeAction : DiscoveryNodeAction
     );
 
     const redeemerNodeValidator = Data.to("LinkedListAct", NodeValidatorAction);
@@ -258,7 +298,11 @@ export class TasteTest implements AbstractTasteTest {
       ownNode = args.utxos[0];
     } else {
       const nodeUTXOs = await this.lucid.utxosAt(nodeValidatorAddr);
-      ownNode = findOwnNode(nodeUTXOs, userKey);
+      ownNode = findOwnNode(
+        nodeUTXOs,
+        userKey,
+        this._getTasteTestTypeFromArgs(args).tasteTestType
+      );
     }
 
     if (!ownNode || !ownNode.datum) {
@@ -328,6 +372,8 @@ export class TasteTest implements AbstractTasteTest {
       throw new Error("Missing wallet's payment credential hash.");
     }
 
+    const isLiquidityTasteTest =
+      this._getTasteTestTypeFromArgs(args).tasteTestType === "liquidity";
     const nodeUTXOS = args.utxos
       ? args.utxos
       : await this.lucid.utxosAt(nodeValidatorAddr);
@@ -337,38 +383,64 @@ export class TasteTest implements AbstractTasteTest {
       ownNode = nodeUTXOS[0];
     } else {
       const nodeUTXOs = await this.lucid.utxosAt(nodeValidatorAddr);
-      ownNode = findOwnNode(nodeUTXOs, userKey);
+      ownNode = findOwnNode(
+        nodeUTXOs,
+        userKey,
+        this._getTasteTestTypeFromArgs(args).tasteTestType
+      );
     }
 
     if (!ownNode || !ownNode.datum) {
       throw new Error("Could not find covering node.");
     }
 
-    const nodeDatum = Data.from(ownNode.datum, SetNode);
+    const nodeDatum = Data.from(
+      ownNode.datum,
+      isLiquidityTasteTest ? LiquiditySetNode : SetNode
+    );
 
     let prevNode: UTxO | undefined;
     if (args.utxos) {
       prevNode = args.utxos[0];
     } else {
-      prevNode = findPrevNode(nodeUTXOS, userKey);
+      prevNode = findPrevNode(
+        nodeUTXOS,
+        userKey,
+        this._getTasteTestTypeFromArgs(args).tasteTestType
+      );
     }
 
     if (!prevNode || !prevNode.datum) {
       throw new Error("Could not find previous node.");
     }
 
-    const prevNodeDatum = Data.from(prevNode.datum, SetNode);
+    const prevNodeDatum = Data.from(
+      prevNode.datum,
+      isLiquidityTasteTest ? LiquiditySetNode : SetNode
+    );
 
     const assets = {
       [toUnit(nodePolicyId, fromText(SETNODE_PREFIX) + userKey)]: -1n,
     };
 
-    const newPrevNode: SetNode = {
-      key: prevNodeDatum.key,
-      next: nodeDatum.next,
-    };
+    let newPrevNode: SetNode | LiquiditySetNode | undefined;
+    if (isLiquidityTasteTest) {
+      newPrevNode = {
+        key: prevNodeDatum.key,
+        next: nodeDatum.next,
+        commitment: BigInt(0),
+      };
+    } else {
+      newPrevNode = {
+        key: prevNodeDatum.key,
+        next: nodeDatum.next,
+      };
+    }
 
-    const newPrevNodeDatum = Data.to(newPrevNode, SetNode);
+    const newPrevNodeDatum = Data.to(
+      newPrevNode,
+      isLiquidityTasteTest ? LiquiditySetNode : SetNode
+    );
 
     const redeemerNodePolicy = Data.to(
       {
@@ -377,7 +449,7 @@ export class TasteTest implements AbstractTasteTest {
           coveringNode: newPrevNode,
         },
       },
-      DiscoveryNodeAction
+      isLiquidityTasteTest ? DiscoveryNodeAction : LiquidityNodeAction
     );
 
     const redeemerNodeValidator = Data.to("LinkedListAct", NodeValidatorAction);
@@ -620,5 +692,21 @@ export class TasteTest implements AbstractTasteTest {
     }
 
     return userKey;
+  }
+
+  /**
+   * A utility method to default the Taste Test type to liquidity if not set.
+   *
+   * @param {IBaseArgs} args The base arguments.
+   * @returns {IBaseArgs}
+   */
+  private _getTasteTestTypeFromArgs(
+    args: IBaseArgs
+  ): IBaseArgs & { tasteTestType: TTasteTestType } {
+    if (!args.tasteTestType) {
+      args.tasteTestType = "liquidity";
+    }
+
+    return args as IBaseArgs & { tasteTestType: TTasteTestType };
   }
 }

--- a/packages/taste-test/src/lib/classes/TasteTest.class.ts
+++ b/packages/taste-test/src/lib/classes/TasteTest.class.ts
@@ -130,7 +130,7 @@ export class TasteTest implements AbstractTasteTest {
     }
 
     const isLiquidityTasteTest =
-      this._getTasteTestTypeFromArgs(args).tasteTestType === "liquidity";
+      this._getTasteTestTypeFromArgs(args) === "liquidity";
     const nodeValidator = await this.getNodeValidatorFromArgs(args);
     const nodeValidatorAddr =
       this.lucid.utils.validatorToAddress(nodeValidator);
@@ -148,7 +148,7 @@ export class TasteTest implements AbstractTasteTest {
       coveringNode = findCoveringNode(
         nodeUTXOs,
         userKey,
-        this._getTasteTestTypeFromArgs(args).tasteTestType
+        this._getTasteTestTypeFromArgs(args)
       );
     }
 
@@ -156,7 +156,7 @@ export class TasteTest implements AbstractTasteTest {
       const hasOwnNode = findOwnNode(
         nodeUTXOs,
         userKey,
-        this._getTasteTestTypeFromArgs(args).tasteTestType
+        this._getTasteTestTypeFromArgs(args)
       );
       if (hasOwnNode && updateFallback) {
         return this.update({ ...args });
@@ -301,7 +301,7 @@ export class TasteTest implements AbstractTasteTest {
       ownNode = findOwnNode(
         nodeUTXOs,
         userKey,
-        this._getTasteTestTypeFromArgs(args).tasteTestType
+        this._getTasteTestTypeFromArgs(args)
       );
     }
 
@@ -373,7 +373,7 @@ export class TasteTest implements AbstractTasteTest {
     }
 
     const isLiquidityTasteTest =
-      this._getTasteTestTypeFromArgs(args).tasteTestType === "liquidity";
+      this._getTasteTestTypeFromArgs(args) === "liquidity";
     const nodeUTXOS = args.utxos
       ? args.utxos
       : await this.lucid.utxosAt(nodeValidatorAddr);
@@ -386,7 +386,7 @@ export class TasteTest implements AbstractTasteTest {
       ownNode = findOwnNode(
         nodeUTXOs,
         userKey,
-        this._getTasteTestTypeFromArgs(args).tasteTestType
+        this._getTasteTestTypeFromArgs(args)
       );
     }
 
@@ -406,7 +406,7 @@ export class TasteTest implements AbstractTasteTest {
       prevNode = findPrevNode(
         nodeUTXOS,
         userKey,
-        this._getTasteTestTypeFromArgs(args).tasteTestType
+        this._getTasteTestTypeFromArgs(args)
       );
     }
 
@@ -698,15 +698,13 @@ export class TasteTest implements AbstractTasteTest {
    * A utility method to default the Taste Test type to liquidity if not set.
    *
    * @param {IBaseArgs} args The base arguments.
-   * @returns {IBaseArgs}
+   * @returns {TTasteTestType}
    */
-  private _getTasteTestTypeFromArgs(
-    args: IBaseArgs
-  ): IBaseArgs & { tasteTestType: TTasteTestType } {
+  private _getTasteTestTypeFromArgs(args: IBaseArgs): TTasteTestType {
     if (!args.tasteTestType) {
       args.tasteTestType = "liquidity";
     }
 
-    return args as IBaseArgs & { tasteTestType: TTasteTestType };
+    return args.tasteTestType as TTasteTestType;
   }
 }

--- a/packages/taste-test/src/utils.ts
+++ b/packages/taste-test/src/utils.ts
@@ -1,12 +1,14 @@
 import { Data, UTxO } from "lucid-cardano";
 
-import { SetNode } from "./@types/contracts";
+import { TTasteTestType } from "./@types";
+import { LiquiditySetNode, SetNode } from "./@types/contracts";
 
 /**
  * Finds the UTxO node that covers a given user key.
  *
  * @param {UTxO[]} utxos - An array of UTxO objects to search through.
  * @param {string} userKey - The user key to find the covering node for.
+ * @param {TTasteTestType} ttType - The type of Taste Test we are using.
  * @returns {UTxO|undefined} - The covering UTxO node, or undefined if no covering node is found.
  *
  * @example
@@ -14,13 +16,20 @@ import { SetNode } from "./@types/contracts";
  * const userKey = 'someUserKey';
  * const coveringNode = findCoveringNode(utxos, userKey);
  */
-export const findCoveringNode = (utxos: UTxO[], userKey: string) =>
+export const findCoveringNode = (
+  utxos: UTxO[],
+  userKey: string,
+  ttType: TTasteTestType
+) =>
   utxos.find((value) => {
     if (!value.datum) {
       return false;
     }
 
-    const datum = Data.from(value.datum, SetNode);
+    const datum = Data.from(
+      value.datum,
+      ttType === "liquidity" ? LiquiditySetNode : SetNode
+    );
     return (
       (datum.key == null || datum.key < userKey) &&
       (datum.next == null || userKey < datum.next)
@@ -32,19 +41,27 @@ export const findCoveringNode = (utxos: UTxO[], userKey: string) =>
  *
  * @param {UTxO[]} utxos - An array of unspent transaction outputs (UTXOs).
  * @param {string} userKey - The unique identifier key for the user, used to find a specific node in the UTXOs.
+ * @param {TTasteTestType} ttType - The type of Taste Test we are using.
  * @returns {UTxO | undefined} - Returns the UTXO that contains the user's node if found, otherwise returns undefined.
  *
  * This function iterates through the provided `utxos`, attempting to match the `userKey` with a key within the datum of each UTXO.
  * If a match is found, it indicates that the UTXO belongs to the user's node, and this UTXO is returned.
  * If no matching node is found in the list of UTXOs, the function returns undefined, indicating the user's node was not found.
  */
-export const findOwnNode = (utxos: UTxO[], userKey: string) =>
+export const findOwnNode = (
+  utxos: UTxO[],
+  userKey: string,
+  ttType: TTasteTestType
+) =>
   utxos.find((value) => {
     if (!value.datum) {
       return false;
     }
 
-    const nodeData = Data.from(value.datum, SetNode);
+    const nodeData = Data.from(
+      value.datum,
+      ttType === "liquidity" ? LiquiditySetNode : SetNode
+    );
     return nodeData.key === userKey;
   });
 
@@ -53,19 +70,27 @@ export const findOwnNode = (utxos: UTxO[], userKey: string) =>
  *
  * @param {UTxO[]} utxos - An array of unspent transaction outputs (UTXOs).
  * @param {string} userKey - The unique identifier key for the user, used to find a specific node in the UTXOs.
+ * @param {TTasteTestType} ttType - The type of Taste Test we are using.
  * @returns {UTxO | undefined} - Returns the UTXO that contains the previous node of the user's node if found, otherwise returns undefined.
  *
  * This function iterates through the provided `utxos`, attempting to match the `userKey` with a key within the datum of each UTXO.
  * If a match is found, it indicates that the UTXO belongs to the user's node, and the UTXO referenced as the previous node is returned.
  * If no matching node is found in the list of UTXOs, the function returns undefined, indicating the previous node of the user's node was not found.
  */
-export const findPrevNode = (utxos: UTxO[], userKey: string) =>
+export const findPrevNode = (
+  utxos: UTxO[],
+  userKey: string,
+  ttType: TTasteTestType
+) =>
   utxos.find((value) => {
     if (!value.datum) {
       return false;
     }
 
-    const datum = Data.from(value.datum, SetNode);
+    const datum = Data.from(
+      value.datum,
+      ttType === "liquidity" ? LiquiditySetNode : SetNode
+    );
     return datum?.next === userKey;
   });
 


### PR DESCRIPTION
Adds support for two Taste Test types: Basic and Liquidity.

- **Basic**: A taste test that ends by distributing the other side of the pair.
- **Liquidity**: A taste test that ends by creating a pool and distributing the LP tokens.