### PR TITLE
Temp: Prevent Decaying Fees

### DIFF
--- a/docs/typescript/core/classes/Lucid.TxBuilderLucidV3.md
+++ b/docs/typescript/core/classes/Lucid.TxBuilderLucidV3.md
@@ -124,7 +124,7 @@ TxBuilder.cancel
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:503](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L503)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:514](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L514)
 
 ___
 
@@ -154,7 +154,7 @@ TxBuilder.deposit
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:655](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L655)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:666](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L666)
 
 ___
 
@@ -179,7 +179,7 @@ The generated Bech32 address.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:886](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L886)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:897](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L897)
 
 ___
 
@@ -268,7 +268,7 @@ Throws an error if the retrieval of UTXOs fails or if no UTXOs are available.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:932](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L932)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:943](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L943)
 
 ___
 
@@ -308,7 +308,7 @@ of pool NFTs, metadata, pool assets, and initial liquidity tokens,
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `mintPoolArgs` | [`IMintV3PoolConfigArgs`](../interfaces/Core.IMintV3PoolConfigArgs.md) | Configuration arguments for minting the pool, including assets, fee parameters, owner address, protocol fee, and referral fee. - assetA: The amount and metadata of assetA. This is a bit misleading because the assets are lexicographically ordered anyway. - assetB: The amount and metadata of assetB. This is a bit misleading because the assets are lexicographically ordered anyway. - fees: A pair of fees, denominated out of 10 thousand, that correspond to their respective index in marketTimings. - marketTimings: The POSIX timestamp for when the fee should start (market open), and stop (fee progression ends). - ownerAddress: Who the generated LP tokens should be sent to. - protocolFee: The fee gathered for the protocol treasury. |
+| `mintPoolArgs` | [`IMintV3PoolConfigArgs`](../interfaces/Core.IMintV3PoolConfigArgs.md) | Configuration arguments for minting the pool, including assets, fee parameters, owner address, protocol fee, and referral fee. - assetA: The amount and metadata of assetA. This is a bit misleading because the assets are lexicographically ordered anyway. - assetB: The amount and metadata of assetB. This is a bit misleading because the assets are lexicographically ordered anyway. - fees: A pair of fees, denominated out of 10 thousand, that correspond to their respective index in marketTimings. - - **NOTE**: Fees must be the same value until decay is supported by scoopers. - marketTimings: The POSIX timestamp for when the fee should start (market open), and stop (fee progression ends). - ownerAddress: Who the generated LP tokens should be sent to. - protocolFee: The fee gathered for the protocol treasury. |
 
 #### Returns
 
@@ -322,7 +322,7 @@ Throws an error if the transaction fails to build or submit.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:303](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L303)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:304](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L304)
 
 ___
 
@@ -379,7 +379,7 @@ TxBuilder.swap
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:450](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L450)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:461](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L461)
 
 ___
 
@@ -411,7 +411,7 @@ TxBuilder.update
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:569](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L569)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:580](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L580)
 
 ___
 
@@ -441,7 +441,7 @@ TxBuilder.withdraw
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:703](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L703)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:714](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L714)
 
 ___
 
@@ -471,7 +471,7 @@ TxBuilder.zap
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:748](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L748)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:759](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L759)
 
 ___
 

--- a/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts
+++ b/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts
@@ -293,6 +293,7 @@ export class TxBuilderLucidV3 extends TxBuilder {
    *  - assetA: The amount and metadata of assetA. This is a bit misleading because the assets are lexicographically ordered anyway.
    *  - assetB: The amount and metadata of assetB. This is a bit misleading because the assets are lexicographically ordered anyway.
    *  - fees: A pair of fees, denominated out of 10 thousand, that correspond to their respective index in marketTimings.
+   *  - - **NOTE**: Fees must be the same value until decay is supported by scoopers.
    *  - marketTimings: The POSIX timestamp for when the fee should start (market open), and stop (fee progression ends).
    *  - ownerAddress: Who the generated LP tokens should be sent to.
    *  - protocolFee: The fee gathered for the protocol treasury.
@@ -312,6 +313,16 @@ export class TxBuilderLucidV3 extends TxBuilder {
       protocolFee,
       referralFee,
     } = new MintV3PoolConfig(mintPoolArgs).buildArgs();
+
+    /**
+     * @todo
+     * This will be removed once decaying fees are supported by scoopers.
+     */
+    if (fees[0] !== fees[1]) {
+      throw new Error(
+        "Decaying fees are currently not supported in the scoopers. For now, use the same fee for both start and end values."
+      );
+    }
 
     const [userUtxos, { hash: poolPolicyId }, references, settings] =
       await Promise.all([


### PR DESCRIPTION
This PR adds a check in the main method for minting a pool on the `EContractVersion.V3` type. Currently, scoopers are not updated to calculate the decaying fee, so attempting to trade against a pool with this parameter will fail.

Updates to the scoopers to support this will happen after launch, so this adds a temporary blocker to the SDK if a user tries to mint a pool with decaying fees. The reason is because user's would not be able to submit supported trades against this pool for an indeterminate amount of time.

This blocker will be removed once scoopers support decaying fees.