### PR TITLE
fix: pass `hasFees` arg to tt `claim` fn

### DIFF
--- a/docs/typescript/taste-test/classes/TasteTestLucid.md
+++ b/docs/typescript/taste-test/classes/TasteTestLucid.md
@@ -57,7 +57,7 @@ to a transaction.
 
 #### Defined in
 
-[taste-test/src/lib/classes/TasteTest.Lucid.class.ts:699](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts#L699)
+[taste-test/src/lib/classes/TasteTest.Lucid.class.ts:703](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts#L703)
 
 ___
 
@@ -79,7 +79,7 @@ A utility method to default the Taste Test type to liquidity if not set.
 
 #### Defined in
 
-[taste-test/src/lib/classes/TasteTest.Lucid.class.ts:685](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts#L685)
+[taste-test/src/lib/classes/TasteTest.Lucid.class.ts:689](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts#L689)
 
 ___
 
@@ -158,7 +158,7 @@ Throws an error if the transaction cannot be completed or if there are issues wi
 
 #### Defined in
 
-[taste-test/src/lib/classes/TasteTest.Lucid.class.ts:585](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts#L585)
+[taste-test/src/lib/classes/TasteTest.Lucid.class.ts:589](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts#L589)
 
 ___
 
@@ -232,7 +232,7 @@ If neither stake nor payment credentials could be determined from the address.
 
 #### Defined in
 
-[taste-test/src/lib/classes/TasteTest.Lucid.class.ts:665](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts#L665)
+[taste-test/src/lib/classes/TasteTest.Lucid.class.ts:669](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts#L669)
 
 ___
 

--- a/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts
+++ b/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts
@@ -556,7 +556,11 @@ export class TasteTestLucid implements AbstractTasteTest {
       this._attachScriptsOrReferenceInputs(tx, args.scripts.validator),
     ]);
 
-    return this.completeTx({ tx, referralFee: args.referralFee });
+    return this.completeTx({
+      hasFees: true,
+      tx,
+      referralFee: args.referralFee,
+    });
   }
 
   /**


### PR DESCRIPTION
Our current `claim` function for Taste Tests doesn't return the `deposit`. Fixed by passing the `hasFees` flag to the `completeTx` fn call.