### PR TITLE
Handle time slightly differently

### DIFF
--- a/packages/taste-test/src/@types/index.ts
+++ b/packages/taste-test/src/@types/index.ts
@@ -79,6 +79,8 @@ export type TScriptType =
  * Common arguments for the deposit and update methods of the TasteTest class instance.
  */
 export interface IBaseArgs {
+  time?: number;
+  deadline?: number;
   referralFee?: ITxBuilderReferralFee;
   validatorAddress: string;
   scripts: {
@@ -108,8 +110,8 @@ export interface IUpdateArgs extends IDepositArgs {
  * Arguments for the deposit withdraw of the TasteTest class instance.
  */
 export interface IWithdrawArgs extends IBaseArgs {
-  deadline: number;
   penaltyAddress: string;
+  deadline: number;
 }
 
 /**

--- a/packages/taste-test/src/lib/contants.ts
+++ b/packages/taste-test/src/lib/contants.ts
@@ -6,5 +6,6 @@ export const FOLDING_FEE_ADA = 1_000_000n;
 export const MIN_COMMITMENT_ADA = 1_000_000n;
 export const TT_UTXO_ADDITIONAL_ADA = NODE_DEPOSIT_ADA + FOLDING_FEE_ADA * 2n;
 
-export const VALID_FROM_TOLERANCE_MS = 100_000;
-export const VALID_TO_TOLERANCE_MS = 1000_000;
+export const VALID_FROM_TOLERANCE_MS = 20_000;
+// TODO: return this from the API
+export const VALID_TO_TOLERANCE_MS = 600_000;


### PR DESCRIPTION
Allow passing in a time, so we can read from server time; correctly truncate to deadline where appropriate