### PR TITLE
Allow minting exotic pairs for V3 Pools

### DIFF
--- a/docs/typescript/core/classes/Lucid.TxBuilderLucidV3.md
+++ b/docs/typescript/core/classes/Lucid.TxBuilderLucidV3.md
@@ -124,7 +124,7 @@ TxBuilder.cancel
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:508](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L508)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:551](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L551)
 
 ___
 
@@ -154,7 +154,7 @@ TxBuilder.deposit
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:660](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L660)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:703](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L703)
 
 ___
 
@@ -179,7 +179,7 @@ The generated Bech32 address.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:891](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L891)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:934](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L934)
 
 ___
 
@@ -242,26 +242,18 @@ ___
 
 ### getUtxosForPoolMint
 
-▸ **getUtxosForPoolMint**(`assets`, `additionalAda?`): `Promise`\<`UTxO`[]\>
+▸ **getUtxosForPoolMint**(): `Promise`\<`UTxO`[]\>
 
 Retrieves the list of UTXOs associated with the wallet, sorts them first by transaction hash (`txHash`)
-in ascending order and then by output index (`outputIndex`) in ascending order, and returns the first UTXO
-in the sorted list to act as the `seed`, and any others required to satisfy the required deposits.
-
-#### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `assets` | [`AssetAmount`\<`IAssetAmountMetadata`\>, `AssetAmount`\<`IAssetAmountMetadata`\>] | The pool assets being deposited. They will automatically be sorted. |
-| `additionalAda` | `bigint` | - |
+in ascending order and then by output index (`outputIndex`) in ascending order, and returns them for Lucid
+to collect from.
 
 #### Returns
 
 `Promise`\<`UTxO`[]\>
 
-A promise that resolves to an array of UTXOs for the transaction. The first UTXO in the sorted list
-is the seed (used for generating a unique pool ident, etc). The array includes any other required inputs to satisfy the
-deposit requirements of the pool being minted.
+A promise that resolves to an array of UTXOs for the transaction. Sorting is required
+because the first UTXO in the sorted list is the seed (used for generating a unique pool ident, etc).
 
 **`Throws`**
 
@@ -269,7 +261,7 @@ Throws an error if the retrieval of UTXOs fails or if no UTXOs are available.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:937](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L937)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:977](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L977)
 
 ___
 
@@ -380,7 +372,7 @@ TxBuilder.swap
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:454](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L454)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:497](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L497)
 
 ___
 
@@ -412,7 +404,7 @@ TxBuilder.update
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:574](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L574)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:617](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L617)
 
 ___
 
@@ -442,7 +434,7 @@ TxBuilder.withdraw
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:708](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L708)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:751](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L751)
 
 ___
 
@@ -472,7 +464,7 @@ TxBuilder.zap
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:753](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L753)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:796](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L796)
 
 ___
 

--- a/docs/typescript/core/classes/Lucid.TxBuilderLucidV3.md
+++ b/docs/typescript/core/classes/Lucid.TxBuilderLucidV3.md
@@ -38,7 +38,7 @@ TxBuilder.constructor
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:100](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L100)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:103](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L103)
 
 ## Properties
 
@@ -54,7 +54,7 @@ TxBuilder.datumBuilder
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:102](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L102)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:105](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L105)
 
 ___
 
@@ -66,7 +66,7 @@ A configured Lucid instance to use.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:101](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L101)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:104](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L104)
 
 ## Methods
 
@@ -94,7 +94,7 @@ An internal shortcut method to avoid having to pass in the network all the time.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:134](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L134)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:137](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L137)
 
 ___
 
@@ -124,7 +124,7 @@ TxBuilder.cancel
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:551](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L551)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:539](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L539)
 
 ___
 
@@ -154,7 +154,7 @@ TxBuilder.deposit
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:703](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L703)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:691](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L691)
 
 ___
 
@@ -179,7 +179,7 @@ The generated Bech32 address.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:934](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L934)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:922](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L922)
 
 ___
 
@@ -197,7 +197,7 @@ using the Lucid provider.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:176](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L176)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:179](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L179)
 
 ___
 
@@ -215,7 +215,7 @@ using the Lucid provider.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:196](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L196)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:199](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L199)
 
 ___
 
@@ -236,7 +236,7 @@ will re-populate with real data.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:148](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L148)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:151](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L151)
 
 ___
 
@@ -261,7 +261,7 @@ Throws an error if the retrieval of UTXOs fails or if no UTXOs are available.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:977](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L977)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:965](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L965)
 
 ___
 
@@ -285,7 +285,7 @@ before returning a response.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:219](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L219)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:222](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L222)
 
 ___
 
@@ -315,7 +315,7 @@ Throws an error if the transaction fails to build or submit.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:303](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L303)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:306](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L306)
 
 ___
 
@@ -342,7 +342,7 @@ fee payment if a [ITxBuilderReferralFee](../interfaces/Core.ITxBuilderReferralFe
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:256](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L256)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:259](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L259)
 
 ___
 
@@ -372,7 +372,7 @@ TxBuilder.swap
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:497](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L497)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:485](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L485)
 
 ___
 
@@ -404,7 +404,7 @@ TxBuilder.update
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:617](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L617)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:605](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L605)
 
 ___
 
@@ -434,7 +434,7 @@ TxBuilder.withdraw
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:751](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L751)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:739](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L739)
 
 ___
 
@@ -464,7 +464,7 @@ TxBuilder.zap
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:796](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L796)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:784](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L784)
 
 ___
 
@@ -495,4 +495,4 @@ Helper method to get a specific parameter of the transaction builder.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:122](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L122)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:125](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L125)

--- a/docs/typescript/core/classes/Lucid.TxBuilderLucidV3.md
+++ b/docs/typescript/core/classes/Lucid.TxBuilderLucidV3.md
@@ -124,7 +124,7 @@ TxBuilder.cancel
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:515](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L515)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:508](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L508)
 
 ___
 
@@ -154,7 +154,7 @@ TxBuilder.deposit
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:667](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L667)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:660](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L660)
 
 ___
 
@@ -179,7 +179,7 @@ The generated Bech32 address.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:898](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L898)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:891](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L891)
 
 ___
 
@@ -242,7 +242,7 @@ ___
 
 ### getUtxosForPoolMint
 
-▸ **getUtxosForPoolMint**(`assets`): `Promise`\<`UTxO`[]\>
+▸ **getUtxosForPoolMint**(`assets`, `additionalAda?`): `Promise`\<`UTxO`[]\>
 
 Retrieves the list of UTXOs associated with the wallet, sorts them first by transaction hash (`txHash`)
 in ascending order and then by output index (`outputIndex`) in ascending order, and returns the first UTXO
@@ -253,6 +253,7 @@ in the sorted list to act as the `seed`, and any others required to satisfy the 
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `assets` | [`AssetAmount`\<`IAssetAmountMetadata`\>, `AssetAmount`\<`IAssetAmountMetadata`\>] | The pool assets being deposited. They will automatically be sorted. |
+| `additionalAda` | `bigint` | - |
 
 #### Returns
 
@@ -268,7 +269,7 @@ Throws an error if the retrieval of UTXOs fails or if no UTXOs are available.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:944](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L944)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:937](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L937)
 
 ___
 
@@ -308,7 +309,7 @@ of pool NFTs, metadata, pool assets, and initial liquidity tokens,
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `mintPoolArgs` | [`IMintV3PoolConfigArgs`](../interfaces/Core.IMintV3PoolConfigArgs.md) | Configuration arguments for minting the pool, including assets, fee parameters, owner address, protocol fee, and referral fee. - assetA: The amount and metadata of assetA. This is a bit misleading because the assets are lexicographically ordered anyway. - assetB: The amount and metadata of assetB. This is a bit misleading because the assets are lexicographically ordered anyway. - fees: A pair of fees, denominated out of 10 thousand, that correspond to their respective index in marketTimings. - - **NOTE**: Fees must be the same value until decay is supported by scoopers. - marketTimings: The POSIX timestamp for when the fee should start (market open), and stop (fee progression ends). - ownerAddress: Who the generated LP tokens should be sent to. - protocolFee: The fee gathered for the protocol treasury. |
+| `mintPoolArgs` | [`IMintV3PoolConfigArgs`](../interfaces/Core.IMintV3PoolConfigArgs.md) | Configuration arguments for minting the pool, including assets, fee parameters, owner address, protocol fee, and referral fee. - assetA: The amount and metadata of assetA. This is a bit misleading because the assets are lexicographically ordered anyway. - assetB: The amount and metadata of assetB. This is a bit misleading because the assets are lexicographically ordered anyway. - fees: A pair of fees, denominated out of 10 thousand, that correspond to their respective index in marketTimings. - - **NOTE**: Fees must be the same value until decay is supported by scoopers. - marketTimings: The POSIX timestamp for when the fee should start (market open), and stop (fee progression ends). - ownerAddress: Who the generated LP tokens should be sent to. |
 
 #### Returns
 
@@ -322,7 +323,7 @@ Throws an error if the transaction fails to build or submit.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:304](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L304)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:303](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L303)
 
 ___
 
@@ -379,7 +380,7 @@ TxBuilder.swap
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:461](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L461)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:454](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L454)
 
 ___
 
@@ -411,7 +412,7 @@ TxBuilder.update
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:581](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L581)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:574](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L574)
 
 ___
 
@@ -441,7 +442,7 @@ TxBuilder.withdraw
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:715](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L715)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:708](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L708)
 
 ___
 
@@ -471,7 +472,7 @@ TxBuilder.zap
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:760](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L760)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:753](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L753)
 
 ___
 

--- a/docs/typescript/taste-test/classes/TasteTestLucid.md
+++ b/docs/typescript/taste-test/classes/TasteTestLucid.md
@@ -57,7 +57,7 @@ to a transaction.
 
 #### Defined in
 
-[taste-test/src/lib/classes/TasteTest.Lucid.class.ts:702](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts#L702)
+[taste-test/src/lib/classes/TasteTest.Lucid.class.ts:720](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts#L720)
 
 ___
 
@@ -79,7 +79,37 @@ A utility method to default the Taste Test type to liquidity if not set.
 
 #### Defined in
 
-[taste-test/src/lib/classes/TasteTest.Lucid.class.ts:688](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts#L688)
+[taste-test/src/lib/classes/TasteTest.Lucid.class.ts:706](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts#L706)
+
+___
+
+### \_getTxBounds
+
+▸ **_getTxBounds**(`time?`, `deadline?`): [`number`, `number`]
+
+Calculates and returns the lower and upper bounds for a transaction based on the provided time and deadline.
+If the `time` parameter is not provided, the current timestamp (`Date.now()`) is used. The lower bound is calculated
+by subtracting a predefined tolerance value (`VALID_FROM_TOLERANCE_MS`) from the `time`. The natural upper bound
+is calculated by adding another predefined tolerance value (`VALID_TO_TOLERANCE_MS`) to the `time`. If a `deadline`
+is provided, the actual upper bound is the minimum between the `deadline - 1` and the natural upper bound; otherwise,
+the natural upper bound is used.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `time?` | `number` | The reference time for the bounds calculation. Defaults to the current timestamp if not provided. |
+| `deadline?` | `number` | An optional deadline that may cap the upper bound. |
+
+#### Returns
+
+[`number`, `number`]
+
+An array containing two elements: the lower and upper bounds for the transaction.
+
+#### Defined in
+
+[taste-test/src/lib/classes/TasteTest.Lucid.class.ts:747](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts#L747)
 
 ___
 
@@ -117,7 +147,7 @@ Throws errors if the claim conditions are not met, such as missing keys, inabili
 
 #### Defined in
 
-[taste-test/src/lib/classes/TasteTest.Lucid.class.ts:483](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts#L483)
+[taste-test/src/lib/classes/TasteTest.Lucid.class.ts:500](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts#L500)
 
 ___
 
@@ -158,7 +188,7 @@ Throws an error if the transaction cannot be completed or if there are issues wi
 
 #### Defined in
 
-[taste-test/src/lib/classes/TasteTest.Lucid.class.ts:588](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts#L588)
+[taste-test/src/lib/classes/TasteTest.Lucid.class.ts:606](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts#L606)
 
 ___
 
@@ -232,7 +262,7 @@ If neither stake nor payment credentials could be determined from the address.
 
 #### Defined in
 
-[taste-test/src/lib/classes/TasteTest.Lucid.class.ts:668](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts#L668)
+[taste-test/src/lib/classes/TasteTest.Lucid.class.ts:686](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts#L686)
 
 ___
 
@@ -279,7 +309,7 @@ Throws an error if the user's payment credential hash is missing or if the node 
 
 #### Defined in
 
-[taste-test/src/lib/classes/TasteTest.Lucid.class.ts:265](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts#L265)
+[taste-test/src/lib/classes/TasteTest.Lucid.class.ts:270](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts#L270)
 
 ___
 
@@ -325,4 +355,4 @@ Throws errors if the withdrawal conditions are not met, such as missing keys, in
 
 #### Defined in
 
-[taste-test/src/lib/classes/TasteTest.Lucid.class.ts:337](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts#L337)
+[taste-test/src/lib/classes/TasteTest.Lucid.class.ts:347](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/taste-test/src/lib/classes/TasteTest.Lucid.class.ts#L347)

--- a/packages/core/src/@types/configs.ts
+++ b/packages/core/src/@types/configs.ts
@@ -102,5 +102,4 @@ export interface IMintV3PoolConfigArgs extends IBaseConfig {
   fees: TFee;
   marketTimings: [number | bigint, number | bigint];
   ownerAddress: string;
-  protocolFee?: bigint;
 }

--- a/packages/core/src/Configs/MintV3PoolConfig.class.ts
+++ b/packages/core/src/Configs/MintV3PoolConfig.class.ts
@@ -12,7 +12,6 @@ export class MintV3PoolConfig extends Config<IMintV3PoolConfigArgs> {
   fees?: TFee;
   marketTimings?: [bigint, bigint];
   ownerAddress?: string;
-  protocolFee?: bigint;
 
   constructor(args?: IMintV3PoolConfigArgs) {
     super();
@@ -25,7 +24,6 @@ export class MintV3PoolConfig extends Config<IMintV3PoolConfigArgs> {
     fees,
     marketTimings,
     ownerAddress,
-    protocolFee,
     referralFee,
   }: IMintV3PoolConfigArgs): void {
     referralFee && this.setReferralFee(referralFee);
@@ -34,11 +32,9 @@ export class MintV3PoolConfig extends Config<IMintV3PoolConfigArgs> {
     this.setFees(fees);
     this.setMarketTimings(marketTimings);
     this.setOwnerAddress(ownerAddress);
-    this.setProtocolFee(protocolFee ?? 2_000_000n);
   }
 
-  buildArgs(): Omit<IMintV3PoolConfigArgs, "protocolFee" | "marketTimings"> & {
-    protocolFee: bigint;
+  buildArgs(): Omit<IMintV3PoolConfigArgs, "marketTimings"> & {
     marketTimings: [bigint, bigint];
   } {
     this.validate();
@@ -48,7 +44,6 @@ export class MintV3PoolConfig extends Config<IMintV3PoolConfigArgs> {
       fees: this.fees as TFee,
       marketTimings: this.marketTimings as [bigint, bigint],
       ownerAddress: this.ownerAddress as string,
-      protocolFee: this.protocolFee ?? 2_000_000n,
       referralFee: this.referralFee,
     };
   }
@@ -75,11 +70,6 @@ export class MintV3PoolConfig extends Config<IMintV3PoolConfigArgs> {
 
   setOwnerAddress(address: string) {
     this.ownerAddress = address;
-    return this;
-  }
-
-  setProtocolFee(fee: bigint) {
-    this.protocolFee = fee;
     return this;
   }
 

--- a/packages/core/src/Configs/__tests__/MintV3PoolConfig.class.test.ts
+++ b/packages/core/src/Configs/__tests__/MintV3PoolConfig.class.test.ts
@@ -35,7 +35,6 @@ describe("MintV3PoolConfig class", () => {
       fees: [20n, 100n],
       marketTimings: [0n, 100n],
       ownerAddress: "addr_test",
-      protocolFee: 2_000_000n,
     });
   });
 

--- a/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts
+++ b/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts
@@ -68,7 +68,7 @@ export interface IDatumBuilderMintPoolV3Args {
   feeDecay: TFee;
   feeDecayEnd: bigint;
   marketOpen: bigint;
-  protocolFee: bigint;
+  depositFee: bigint;
 }
 
 /**
@@ -257,7 +257,7 @@ export class DatumBuilderLucidV3 implements DatumBuilder {
     feeDecay,
     feeDecayEnd,
     marketOpen,
-    protocolFee,
+    depositFee,
     seedUtxo,
   }: IDatumBuilderMintPoolV3Args): TDatumResult<V3Types.TPoolDatum> {
     const ident = DatumBuilderLucidV3.computePoolId(seedUtxo);
@@ -275,7 +275,7 @@ export class DatumBuilderLucidV3 implements DatumBuilder {
       feeFinalized: feeDecayEnd || 0n,
       identifier: ident,
       marketOpen: marketOpen || 0n,
-      protocolFee,
+      protocolFee: depositFee,
     };
 
     const inline = Data.to(newPoolDatum, V3Types.PoolDatum);

--- a/packages/core/src/DatumBuilders/__tests__/DatumBuilder.Lucid.V3/buildMintPoolDatum.test.ts
+++ b/packages/core/src/DatumBuilders/__tests__/DatumBuilder.Lucid.V3/buildMintPoolDatum.test.ts
@@ -14,7 +14,7 @@ const defaultArgs: IDatumBuilderMintPoolV3Args = {
   feeDecay: [5n, 10n],
   feeDecayEnd: 5n,
   marketOpen: 123n,
-  protocolFee: 2_000_000n,
+  depositFee: 2_000_000n,
   seedUtxo: {
     address:
       "addr_test1qrp8nglm8d8x9w783c5g0qa4spzaft5z5xyx0kp495p8wksjrlfzuz6h4ssxlm78v0utlgrhryvl2gvtgp53a6j9zngqtjfk6s",

--- a/packages/core/src/TestUtilities/mockData.ts
+++ b/packages/core/src/TestUtilities/mockData.ts
@@ -19,6 +19,7 @@ interface INetworkData {
   assets: {
     tada: AssetAmount<IAssetAmountMetadata>;
     tindy: AssetAmount<IAssetAmountMetadata>;
+    usdc: AssetAmount<IAssetAmountMetadata>;
     v1LpToken: AssetAmount<IAssetAmountMetadata>;
     v3LpToken: AssetAmount<IAssetAmountMetadata>;
   };
@@ -98,6 +99,11 @@ const PREVIEW_DATA: INetworkData = {
       assetId:
         "fa3eff2047fdf9293c5feef4dc85ce58097ea1c6da4845a351535183.74494e4459",
       decimals: 0,
+    }),
+    usdc: new AssetAmount(20_000_000n, {
+      assetId:
+        "99b071ce8580d6a3a11b4902145adb8bfd0d2a03935af8cf66403e15.55534443",
+      decimals: 6,
     }),
     v1LpToken: new AssetAmount(100_000_000n, {
       assetId:

--- a/packages/core/src/TxBuilders/__tests__/TxBuilder.Lucid.V3.class.test.ts
+++ b/packages/core/src/TxBuilders/__tests__/TxBuilder.Lucid.V3.class.test.ts
@@ -630,11 +630,11 @@ describe("TxBuilderLucidV3", () => {
 
     /**
      * Since we're depositing exotic assets, we expect:
-     * - 2.5 ADA to cover minUtxo for exotic pair
+     * - 1.538670 minAda required for exotic pair
      * - 2 ADA for metadata ref token
      * - 2 ADA for sending back LP tokens
      */
-    expect(fees.deposit.amount.toString()).toEqual("6500000");
+    expect(fees.deposit.amount.toString()).toEqual("5538670");
 
     const { builtTx } = await build();
 
@@ -676,7 +676,7 @@ describe("TxBuilderLucidV3", () => {
     const poolDepositedNFT =
       poolDepositAssets[
         "8140c4b89428fc264e90b10c71c53a4c3f9ce52b676bf1d9b51eb9ca"
-      ]["000de140605dc1c671125b2bab364b371deb4845ce098df177dd21bc88a305a0"];
+      ]["000de1409e67cc006063ea055629552650664979d7c92d47e342e5340ef77550"];
 
     [poolDepositedAssetA, poolDepositedAssetB, poolDepositedNFT].forEach(
       (val) => expect(val).not.toBeUndefined()
@@ -693,7 +693,7 @@ describe("TxBuilderLucidV3", () => {
         poolOutput.datum()?.as_data()?.to_bytes() as Uint8Array
       ).toString("hex")
     ).toEqual(
-      "d8185881d8799f581c605dc1c671125b2bab364b371deb4845ce098df177dd21bc88a305a09f9f581c99b071ce8580d6a3a11b4902145adb8bfd0d2a03935af8cf66403e154455534443ff9f581cfa3eff2047fdf9293c5feef4dc85ce58097ea1c6da4845a3515351834574494e4459ffff1a01312d009f0505ff051927101a002625a0ff"
+      "d8185881d8799f581c9e67cc006063ea055629552650664979d7c92d47e342e5340ef775509f9f581c99b071ce8580d6a3a11b4902145adb8bfd0d2a03935af8cf66403e154455534443ff9f581cfa3eff2047fdf9293c5feef4dc85ce58097ea1c6da4845a3515351834574494e4459ffff1a01312d009f0505ff051927101a00177a6eff"
     );
 
     /**
@@ -710,7 +710,7 @@ describe("TxBuilderLucidV3", () => {
     const metadataDepositedAssetA = metadataOutput.amount().coin().to_str();
     const metadataDepositedNFT =
       metadataDepositAssets[params.blueprint.validators[1].hash][
-        "000643b0605dc1c671125b2bab364b371deb4845ce098df177dd21bc88a305a0"
+        "000643b09e67cc006063ea055629552650664979d7c92d47e342e5340ef77550"
       ];
 
     [metadataDepositedAssetA, metadataDepositedNFT].forEach((val) =>
@@ -735,7 +735,7 @@ describe("TxBuilderLucidV3", () => {
     const lpTokensReturnedADA = lpTokensOutput.amount().coin().to_str();
     const lpTokensReturned =
       lpTokensDepositAssets[params.blueprint.validators[1].hash][
-        "0014df10605dc1c671125b2bab364b371deb4845ce098df177dd21bc88a305a0"
+        "0014df109e67cc006063ea055629552650664979d7c92d47e342e5340ef77550"
       ];
 
     [lpTokensReturnedADA, lpTokensReturned].forEach((val) =>


### PR DESCRIPTION
This covers updating the `mintPool` method for `TxBuilder.Lucid.V3.class.ts`, in which we abstract out the original config option for `protocolFees`, and replace it with the following logic:

- If a user is depositing a pair that includes ADA, we don't attach a rider fee to that deposit (since it is covered by the ADA).
- If a user is depositing an exotic pair, we include 2.5 ADA along with those assets as a rider fee.