### PR TITLE
Order Routing

### DIFF
--- a/docs/typescript/core/classes/Lucid.TxBuilderLucidV1.md
+++ b/docs/typescript/core/classes/Lucid.TxBuilderLucidV1.md
@@ -137,7 +137,7 @@ TxBuilder.cancel
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:444](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L444)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:454](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L454)
 
 ___
 
@@ -244,7 +244,7 @@ const migrationResult = await sdk.builder().migrateLiquidityToV3([
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:907](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L907)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:917](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L917)
 
 ___
 
@@ -271,6 +271,36 @@ Returns a new Tx instance from Lucid. Throws an error if not ready.
 #### Defined in
 
 [packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:186](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L186)
+
+___
+
+### orderRouteSwap
+
+▸ **orderRouteSwap**(`args`): `Promise`\<[`IComposedTx`](../interfaces/Core.IComposedTx.md)\<`Tx`, `TxComplete`, `undefined` \| `string`, `Record`\<`string`, `AssetAmount`\<`IAssetAmountMetadata`\>\>\>\>
+
+Performs an order route swap with the given arguments.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `args` | [`IOrderRouteSwapArgs`](../interfaces/Core.IOrderRouteSwapArgs.md) | The arguments for the order route swap. |
+
+#### Returns
+
+`Promise`\<[`IComposedTx`](../interfaces/Core.IComposedTx.md)\<`Tx`, `TxComplete`, `undefined` \| `string`, `Record`\<`string`, `AssetAmount`\<`IAssetAmountMetadata`\>\>\>\>
+
+The result of the transaction.
+
+**`Async`**
+
+#### Overrides
+
+TxBuilder.orderRouteSwap
+
+#### Defined in
+
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:307](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L307)
 
 ___
 
@@ -363,7 +393,7 @@ TxBuilder.update
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:547](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L547)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:557](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L557)
 
 ___
 
@@ -405,7 +435,7 @@ TxBuilder.withdraw
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:687](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L687)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:697](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L697)
 
 ___
 
@@ -447,7 +477,7 @@ TxBuilder.zap
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:739](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L739)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:749](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L749)
 
 ___
 

--- a/docs/typescript/core/classes/Lucid.TxBuilderLucidV1.md
+++ b/docs/typescript/core/classes/Lucid.TxBuilderLucidV1.md
@@ -137,7 +137,7 @@ TxBuilder.cancel
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:296](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L296)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:415](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L415)
 
 ___
 
@@ -244,7 +244,7 @@ const migrationResult = await sdk.builder().migrateLiquidityToV3([
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:760](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L760)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:878](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L878)
 
 ___
 
@@ -363,7 +363,7 @@ TxBuilder.update
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:400](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L400)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:518](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L518)
 
 ___
 
@@ -405,7 +405,7 @@ TxBuilder.withdraw
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:540](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L540)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:658](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L658)
 
 ___
 
@@ -447,7 +447,7 @@ TxBuilder.zap
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:592](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L592)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:710](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L710)
 
 ___
 

--- a/docs/typescript/core/classes/Lucid.TxBuilderLucidV1.md
+++ b/docs/typescript/core/classes/Lucid.TxBuilderLucidV1.md
@@ -39,7 +39,7 @@ TxBuilder.constructor
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:98](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L98)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:100](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L100)
 
 ## Properties
 
@@ -55,7 +55,7 @@ TxBuilder.datumBuilder
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:100](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L100)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:102](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L102)
 
 ___
 
@@ -67,7 +67,7 @@ A configured Lucid instance to use.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:99](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L99)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:101](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L101)
 
 ## Methods
 
@@ -95,7 +95,7 @@ An internal shortcut method to avoid having to pass in the network all the time.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:174](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L174)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:176](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L176)
 
 ___
 
@@ -137,7 +137,7 @@ TxBuilder.cancel
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:415](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L415)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:444](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L444)
 
 ___
 
@@ -158,7 +158,7 @@ will re-populate with real data.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:119](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L119)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:121](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L121)
 
 ___
 
@@ -182,7 +182,7 @@ before returning a response.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:138](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L138)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:140](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L140)
 
 ___
 
@@ -244,7 +244,7 @@ const migrationResult = await sdk.builder().migrateLiquidityToV3([
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:878](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L878)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:907](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L907)
 
 ___
 
@@ -270,7 +270,7 @@ Returns a new Tx instance from Lucid. Throws an error if not ready.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:184](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L184)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:186](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L186)
 
 ___
 
@@ -312,7 +312,7 @@ TxBuilder.swap
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:232](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L232)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:234](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L234)
 
 ___
 
@@ -363,7 +363,7 @@ TxBuilder.update
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:518](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L518)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:547](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L547)
 
 ___
 
@@ -405,7 +405,7 @@ TxBuilder.withdraw
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:658](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L658)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:687](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L687)
 
 ___
 
@@ -447,7 +447,7 @@ TxBuilder.zap
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:710](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L710)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:739](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L739)
 
 ___
 
@@ -476,4 +476,4 @@ Helper method to get a specific parameter of the transaction builder.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:161](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L161)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:163](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L163)

--- a/docs/typescript/core/classes/Lucid.TxBuilderLucidV3.md
+++ b/docs/typescript/core/classes/Lucid.TxBuilderLucidV3.md
@@ -38,7 +38,7 @@ TxBuilder.constructor
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:99](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L99)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:100](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L100)
 
 ## Properties
 
@@ -54,7 +54,7 @@ TxBuilder.datumBuilder
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:101](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L101)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:102](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L102)
 
 ___
 
@@ -66,7 +66,7 @@ A configured Lucid instance to use.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:100](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L100)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:101](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L101)
 
 ## Methods
 
@@ -96,7 +96,7 @@ TxBuilder.cancel
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:560](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L560)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:686](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L686)
 
 ___
 
@@ -126,7 +126,7 @@ TxBuilder.deposit
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:728](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L728)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:854](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L854)
 
 ___
 
@@ -151,7 +151,7 @@ The generated Bech32 address.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:959](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L959)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:1085](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L1085)
 
 ___
 
@@ -169,7 +169,7 @@ using the Lucid provider.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:138](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L138)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:139](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L139)
 
 ___
 
@@ -187,7 +187,7 @@ using the Lucid provider.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:175](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L175)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:176](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L176)
 
 ___
 
@@ -207,7 +207,7 @@ The maxScooperFee as defined by the settings UTXO.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:195](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L195)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:196](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L196)
 
 ___
 
@@ -228,7 +228,7 @@ will re-populate with real data.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:120](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L120)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:121](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L121)
 
 ___
 
@@ -248,7 +248,7 @@ ___
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:156](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L156)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:157](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L157)
 
 ___
 
@@ -273,7 +273,7 @@ Throws an error if the retrieval of UTXOs fails or if no UTXOs are available.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:1002](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L1002)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:1128](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L1128)
 
 ___
 
@@ -297,7 +297,7 @@ before returning a response.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:217](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L217)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:218](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L218)
 
 ___
 
@@ -327,7 +327,7 @@ Throws an error if the transaction fails to build or submit.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:286](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L286)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:287](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L287)
 
 ___
 
@@ -354,7 +354,7 @@ fee payment if a [ITxBuilderReferralFee](../interfaces/Core.ITxBuilderReferralFe
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:240](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L240)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:241](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L241)
 
 ___
 
@@ -384,7 +384,7 @@ TxBuilder.swap
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:506](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L506)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:507](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L507)
 
 ___
 
@@ -416,7 +416,7 @@ TxBuilder.update
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:642](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L642)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:768](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L768)
 
 ___
 
@@ -446,7 +446,7 @@ TxBuilder.withdraw
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:776](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L776)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:902](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L902)
 
 ___
 
@@ -476,4 +476,4 @@ TxBuilder.zap
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:821](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L821)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:947](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L947)

--- a/docs/typescript/core/classes/Lucid.TxBuilderLucidV3.md
+++ b/docs/typescript/core/classes/Lucid.TxBuilderLucidV3.md
@@ -96,7 +96,7 @@ TxBuilder.cancel
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:826](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L826)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:720](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L720)
 
 ___
 
@@ -126,7 +126,7 @@ TxBuilder.deposit
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:994](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L994)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:888](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L888)
 
 ___
 
@@ -151,7 +151,7 @@ The generated Bech32 address.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:1225](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L1225)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:1119](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L1119)
 
 ___
 
@@ -273,7 +273,7 @@ Throws an error if the retrieval of UTXOs fails or if no UTXOs are available.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:1268](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L1268)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:1162](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L1162)
 
 ___
 
@@ -358,6 +358,36 @@ fee payment if a [ITxBuilderReferralFee](../interfaces/Core.ITxBuilderReferralFe
 
 ___
 
+### orderRouteSwap
+
+▸ **orderRouteSwap**(`args`): `Promise`\<[`IComposedTx`](../interfaces/Core.IComposedTx.md)\<`Tx`, `TxComplete`, `undefined` \| `string`, `Record`\<`string`, `AssetAmount`\<`IAssetAmountMetadata`\>\>\>\>
+
+Performs an order route swap with the given arguments.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `args` | [`IOrderRouteSwapArgs`](../interfaces/Core.IOrderRouteSwapArgs.md) | The arguments for the order route swap. |
+
+#### Returns
+
+`Promise`\<[`IComposedTx`](../interfaces/Core.IComposedTx.md)\<`Tx`, `TxComplete`, `undefined` \| `string`, `Record`\<`string`, `AssetAmount`\<`IAssetAmountMetadata`\>\>\>\>
+
+The result of the transaction.
+
+**`Async`**
+
+#### Overrides
+
+TxBuilder.orderRouteSwap
+
+#### Defined in
+
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:579](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L579)
+
+___
+
 ### swap
 
 ▸ **swap**(`swapArgs`): `Promise`\<[`IComposedTx`](../interfaces/Core.IComposedTx.md)\<`Tx`, `TxComplete`, `undefined` \| `string`, `Record`\<`string`, `AssetAmount`\<`IAssetAmountMetadata`\>\>\>\>
@@ -416,7 +446,7 @@ TxBuilder.update
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:908](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L908)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:802](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L802)
 
 ___
 
@@ -446,7 +476,7 @@ TxBuilder.withdraw
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:1042](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L1042)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:936](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L936)
 
 ___
 
@@ -476,4 +506,4 @@ TxBuilder.zap
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:1087](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L1087)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:981](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L981)

--- a/docs/typescript/core/classes/Lucid.TxBuilderLucidV3.md
+++ b/docs/typescript/core/classes/Lucid.TxBuilderLucidV3.md
@@ -96,7 +96,7 @@ TxBuilder.cancel
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:686](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L686)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:826](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L826)
 
 ___
 
@@ -126,7 +126,7 @@ TxBuilder.deposit
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:854](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L854)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:994](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L994)
 
 ___
 
@@ -151,7 +151,7 @@ The generated Bech32 address.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:1085](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L1085)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:1225](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L1225)
 
 ___
 
@@ -273,7 +273,7 @@ Throws an error if the retrieval of UTXOs fails or if no UTXOs are available.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:1128](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L1128)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:1268](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L1268)
 
 ___
 
@@ -416,7 +416,7 @@ TxBuilder.update
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:768](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L768)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:908](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L908)
 
 ___
 
@@ -446,7 +446,7 @@ TxBuilder.withdraw
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:902](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L902)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:1042](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L1042)
 
 ___
 
@@ -476,4 +476,4 @@ TxBuilder.zap
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:947](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L947)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts:1087](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts#L1087)

--- a/docs/typescript/core/enums/Core.EContractVersion.md
+++ b/docs/typescript/core/enums/Core.EContractVersion.md
@@ -13,7 +13,7 @@ of any time that interact with SundaeSwap contracts.
 
 #### Defined in
 
-[packages/core/src/@types/txbuilders.ts:80](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/txbuilders.ts#L80)
+[packages/core/src/@types/txbuilders.ts:82](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/txbuilders.ts#L82)
 
 ___
 
@@ -23,4 +23,4 @@ ___
 
 #### Defined in
 
-[packages/core/src/@types/txbuilders.ts:81](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/txbuilders.ts#L81)
+[packages/core/src/@types/txbuilders.ts:83](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/txbuilders.ts#L83)

--- a/docs/typescript/core/enums/Core.ESwapType.md
+++ b/docs/typescript/core/enums/Core.ESwapType.md
@@ -12,7 +12,7 @@ An enum to represent a Swap order type.
 
 #### Defined in
 
-[packages/core/src/@types/configs.ts:32](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/configs.ts#L32)
+[packages/core/src/@types/configs.ts:33](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/configs.ts#L33)
 
 ___
 
@@ -22,4 +22,4 @@ ___
 
 #### Defined in
 
-[packages/core/src/@types/configs.ts:31](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/configs.ts#L31)
+[packages/core/src/@types/configs.ts:32](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/configs.ts#L32)

--- a/docs/typescript/core/enums/Core.ETxBuilderType.md
+++ b/docs/typescript/core/enums/Core.ETxBuilderType.md
@@ -12,4 +12,4 @@ Holds the acceptable provider types.
 
 #### Defined in
 
-[packages/core/src/@types/txbuilders.ts:59](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/txbuilders.ts#L59)
+[packages/core/src/@types/txbuilders.ts:61](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/txbuilders.ts#L61)

--- a/docs/typescript/core/interfaces/Core.IOrderRouteSwapArgs.md
+++ b/docs/typescript/core/interfaces/Core.IOrderRouteSwapArgs.md
@@ -1,0 +1,6 @@
+# Interface: IOrderRouteSwapArgs
+
+[Core](../modules/Core.md).IOrderRouteSwapArgs
+
+Special arguments for an Order-Route Swap. A combination of
+two swap arguments, but simplified for ease-of-use.

--- a/docs/typescript/core/interfaces/Core.ITxBuilderReferralFee.md
+++ b/docs/typescript/core/interfaces/Core.ITxBuilderReferralFee.md
@@ -14,4 +14,4 @@ The label that prefixes the fee amount in the metadata.
 
 #### Defined in
 
-[packages/core/src/@types/txbuilders.ts:52](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/txbuilders.ts#L52)
+[packages/core/src/@types/txbuilders.ts:54](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/txbuilders.ts#L54)

--- a/docs/typescript/core/modules/Core.md
+++ b/docs/typescript/core/modules/Core.md
@@ -37,6 +37,7 @@
 - [IMigrateYieldFarmingLiquidityConfig](../interfaces/Core.IMigrateYieldFarmingLiquidityConfig.md)
 - [IMintV3PoolConfigArgs](../interfaces/Core.IMintV3PoolConfigArgs.md)
 - [IOrderConfigArgs](../interfaces/Core.IOrderConfigArgs.md)
+- [IOrderRouteSwapArgs](../interfaces/Core.IOrderRouteSwapArgs.md)
 - [IPoolByIdentQuery](../interfaces/Core.IPoolByIdentQuery.md)
 - [IPoolByPairQuery](../interfaces/Core.IPoolByPairQuery.md)
 - [IPoolData](../interfaces/Core.IPoolData.md)

--- a/docs/typescript/core/modules/Core.md
+++ b/docs/typescript/core/modules/Core.md
@@ -324,7 +324,7 @@ A union type to represent all possible swap types.
 
 #### Defined in
 
-[packages/core/src/@types/configs.ts:56](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/configs.ts#L56)
+[packages/core/src/@types/configs.ts:57](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/configs.ts#L57)
 
 ___
 
@@ -355,7 +355,7 @@ The union type to hold all possible builder types.
 
 #### Defined in
 
-[packages/core/src/@types/txbuilders.ts:73](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/txbuilders.ts#L73)
+[packages/core/src/@types/txbuilders.ts:75](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/txbuilders.ts#L75)
 
 ___
 

--- a/packages/core/src/@types/configs.ts
+++ b/packages/core/src/@types/configs.ts
@@ -22,6 +22,7 @@ export interface IBaseConfig {
 export interface IOrderConfigArgs extends IBaseConfig {
   pool: IPoolData;
   orderAddresses: TOrderAddresses;
+  ownerAddress?: string;
 }
 
 /**

--- a/packages/core/src/@types/txbuilders.ts
+++ b/packages/core/src/@types/txbuilders.ts
@@ -83,6 +83,10 @@ export enum EContractVersion {
   V3 = "V3",
 }
 
+/**
+ * Special arguments for an Order-Route Swap. A combination of
+ * two swap arguments, but simplified for ease-of-use.
+ */
 export interface IOrderRouteSwapArgs {
   ownerAddress: string;
   swapA: Omit<ISwapConfigArgs, "orderAddresses" | "ownerAddress">;

--- a/packages/core/src/@types/txbuilders.ts
+++ b/packages/core/src/@types/txbuilders.ts
@@ -1,6 +1,8 @@
 import { AssetAmount, IAssetAmountMetadata } from "@sundaeswap/asset";
 import type { Lucid } from "lucid-cardano";
 
+import { ISwapConfigArgs } from "./configs.js";
+
 /**
  * The full list of calculated fees for a transaction built by a TxBuilder instance.
  */
@@ -79,4 +81,13 @@ export type TWalletBuilder = ILucidBuilder;
 export enum EContractVersion {
   V1 = "V1",
   V3 = "V3",
+}
+
+export interface IOrderRouteSwapArgs {
+  ownerAddress: string;
+  swapA: Omit<ISwapConfigArgs, "orderAddresses" | "ownerAddress">;
+  swapB: Omit<
+    ISwapConfigArgs,
+    "suppliedAsset" | "orderAddresses" | "ownerAddress"
+  >;
 }

--- a/packages/core/src/Abstracts/TxBuilder.abstract.class.ts
+++ b/packages/core/src/Abstracts/TxBuilder.abstract.class.ts
@@ -25,6 +25,7 @@ export abstract class TxBuilder {
   abstract newTxInstance(): unknown;
 
   abstract swap(args: unknown): Promise<IComposedTx>;
+  abstract orderRouteSwap(args: unknown): Promise<IComposedTx>;
   abstract deposit(args: unknown): Promise<IComposedTx>;
   abstract withdraw(args: unknown): Promise<IComposedTx>;
   abstract update(args: unknown): Promise<IComposedTx>;

--- a/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts
+++ b/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts
@@ -219,7 +219,7 @@ export class TxBuilderLucidV1 extends TxBuilder {
    * and completes the transaction by paying to the contract and finalizing the transaction details.
    *
    * @param {ISwapConfigArgs} swapArgs - The configuration arguments for the swap.
-   * @returns {Promise<TransactionResult>} A promise that resolves to the result of the completed transaction.
+   * @returns {Promise<IComposedTx<Tx, TxComplete>>} A promise that resolves to the result of the completed transaction.
    *
    * @async
    * @example
@@ -231,7 +231,7 @@ export class TxBuilderLucidV1 extends TxBuilder {
    *   .then(({ submit }) => submit())
    * ```
    */
-  async swap(swapArgs: ISwapConfigArgs) {
+  async swap(swapArgs: ISwapConfigArgs): Promise<IComposedTx<Tx, TxComplete>> {
     const config = new SwapConfig(swapArgs);
 
     const {
@@ -296,7 +296,17 @@ export class TxBuilderLucidV1 extends TxBuilder {
     });
   }
 
-  async orderRouteSwap(args: IOrderRouteSwapArgs) {
+  /**
+   * Performs an order route swap with the given arguments.
+   *
+   * @async
+   * @param {IOrderRouteSwapArgs} args - The arguments for the order route swap.
+   *
+   * @returns {Promise<IComposedTx<Tx, TxComplete>>} The result of the transaction.
+   */
+  async orderRouteSwap(
+    args: IOrderRouteSwapArgs
+  ): Promise<IComposedTx<Tx, TxComplete>> {
     const isSecondSwapV3 = args.swapB.pool.version === EContractVersion.V3;
 
     const secondSwapBuilder = isSecondSwapV3
@@ -429,7 +439,7 @@ export class TxBuilderLucidV1 extends TxBuilder {
    * sets up the transaction, and completes it.
    *
    * @param {ICancelConfigArgs} cancelArgs - The configuration arguments for the cancel transaction.
-   * @returns {Promise<TransactionResult>} A promise that resolves to the result of the cancel transaction.
+   * @returns {Promise<IComposedTx<Tx, TxComplete>>} A promise that resolves to the result of the cancel transaction.
    *
    * @async
    * @example
@@ -526,7 +536,7 @@ export class TxBuilderLucidV1 extends TxBuilder {
    *
    * @param {{ cancelArgs: ICancelConfigArgs, swapArgs: ISwapConfigArgs }}
    *        The arguments for cancel and swap configurations.
-   * @returns {Promise<TransactionResult>} A promise that resolves to the result of the updated transaction.
+   * @returns {Promise<IComposedTx<Tx, TxComplete>>} A promise that resolves to the result of the updated transaction.
    *
    * @throws
    * @async

--- a/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts
+++ b/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts
@@ -569,7 +569,16 @@ export class TxBuilderLucidV3 extends TxBuilder {
     });
   }
 
-  async orderRouteSwap(args: IOrderRouteSwapArgs) {
+  /**
+   * Performs an order route swap with the given arguments.
+   *
+   * @async
+   * @param {IOrderRouteSwapArgs} args - The arguments for the order route swap.
+   * @returns {Promise<IComposedTx<Tx, TxComplete>>} The result of the transaction.
+   */
+  async orderRouteSwap(
+    args: IOrderRouteSwapArgs
+  ): Promise<IComposedTx<Tx, TxComplete>> {
     const isSecondSwapV1 = args.swapB.pool.version === EContractVersion.V1;
 
     const secondSwapBuilder = isSecondSwapV1
@@ -698,121 +707,6 @@ export class TxBuilderLucidV3 extends TxBuilder {
       referralFee: mergedReferralFee?.payment,
       scooperFee: fees.scooperFee.add(secondSwapData.fees.scooperFee).amount,
     });
-
-    // const swapA = new SwapConfig(args.swapA).buildArgs();
-
-    // const [aReserve, bReserve] = SundaeUtils.sortSwapAssetsWithAmounts([
-    //   new AssetAmount(
-    //     args.swapA.pool.liquidity.aReserve,
-    //     args.swapA.pool.assetA
-    //   ),
-    //   new AssetAmount(
-    //     args.swapA.pool.liquidity.bReserve,
-    //     args.swapA.pool.assetB
-    //   ),
-    // ]);
-
-    // const aOutputAsset =
-    //   swapA.suppliedAsset.metadata.assetId === aReserve.metadata.assetId
-    //     ? bReserve.withAmount(swapA.minReceivable.amount)
-    //     : aReserve.withAmount(swapA.minReceivable.amount);
-
-    // const swapB = new SwapConfig({
-    //   ...args.swapB,
-    //   suppliedAsset: aOutputAsset,
-    // }).buildArgs();
-
-    // const isSecondSwapV1 = swapB.pool.version === EContractVersion.V1;
-
-    // const secondSwapBuilder = isSecondSwapV1
-    //   ? new TxBuilderLucidV1(this.lucid, new DatumBuilderLucidV1(this.network))
-    //   : this;
-    // const secondSwapAddress = isSecondSwapV1
-    //   ? await secondSwapBuilder
-    //       .getValidatorScript("escrow.spend")
-    //       .then(({ compiledCode }) =>
-    //         this.lucid.utils.validatorToAddress({
-    //           type: "PlutusV1",
-    //           script: compiledCode,
-    //         })
-    //       )
-    //   : await (secondSwapBuilder as TxBuilderLucidV3).generateScriptAddress(
-    //       "order.spend",
-    //       args.swapA.ownerAddress ??
-    //         swapA.orderAddresses.DestinationAddress.address
-    //     );
-
-    // const secondSwapData = await secondSwapBuilder.swap({
-    //   ...swapB,
-    //   swapType: args.swapB.swapType,
-    // });
-
-    // let referralFeeAmount = 0n;
-    // if (swapA.referralFee) {
-    //   referralFeeAmount += swapA.referralFee.payment.amount;
-    // }
-
-    // if (swapB.referralFee) {
-    //   referralFeeAmount += swapB.referralFee.payment.amount;
-    // }
-
-    // let mergedReferralFee: ITxBuilderReferralFee | undefined;
-    // if (swapA.referralFee) {
-    //   mergedReferralFee = {
-    //     ...swapA.referralFee,
-    //     payment: swapA.referralFee.payment.withAmount(referralFeeAmount),
-    //   };
-    // } else if (swapB.referralFee) {
-    //   mergedReferralFee = {
-    //     ...swapB.referralFee,
-    //     payment: swapB.referralFee.payment.withAmount(referralFeeAmount),
-    //   };
-    // }
-
-    // const datumHash = this.lucid.utils.datumToHash(
-    //   secondSwapData.datum as string
-    // );
-
-    // const { tx, datum, fees } = await this.swap({
-    //   ...swapA,
-    //   swapType: {
-    //     type: ESwapType.LIMIT,
-    //     minReceivable: swapA.minReceivable,
-    //   },
-    //   orderAddresses: {
-    //     ...swapB.orderAddresses,
-    //     DestinationAddress: {
-    //       address: secondSwapAddress,
-    //       datum: {
-    //         type: isSecondSwapV1 ? EDatumType.HASH : EDatumType.INLINE,
-    //         value: isSecondSwapV1
-    //           ? datumHash
-    //           : (secondSwapData.datum as string),
-    //       },
-    //     },
-    //     AlternateAddress:
-    //       args.swapA.ownerAddress ??
-    //       swapB.orderAddresses.DestinationAddress.address,
-    //   },
-    //   referralFee: mergedReferralFee,
-    // });
-
-    // if (isSecondSwapV1) {
-    //   tx.attachMetadataWithConversion(103251, {
-    //     [`0x${datumHash}`]: SundaeUtils.splitMetadataString(
-    //       secondSwapData.datum as string,
-    //       "0x"
-    //     ),
-    //   });
-    // }
-
-    // return this.completeTx({
-    //   tx,
-    //   datum,
-    //   deposit: ORDER_DEPOSIT_DEFAULT,
-    //   referralFee: mergedReferralFee?.payment,
-    //   scooperFee: fees.scooperFee.add(secondSwapData.fees.scooperFee).amount,
-    // });
   }
 
   /**

--- a/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts
+++ b/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts
@@ -12,6 +12,7 @@ import {
   type TxComplete,
 } from "lucid-cardano";
 
+import { getSwapOutput } from "@sundaeswap/cpp";
 import type {
   ICancelConfigArgs,
   IComposedTx,
@@ -546,6 +547,131 @@ export class TxBuilderLucidV3 extends TxBuilder {
       tx: txInstance,
       datum: inline,
       referralFee: referralFee?.payment,
+    });
+  }
+
+  async orderRouteSwap(args: {
+    swapA: ISwapConfigArgs;
+    swapB: Omit<ISwapConfigArgs, "suppliedAsset">;
+  }): Promise<
+    IComposedTx<
+      unknown,
+      unknown,
+      string | undefined,
+      Record<string, AssetAmount<IAssetAmountMetadata>>
+    >
+  > {
+    const swapA = new SwapConfig(args.swapA).buildArgs();
+
+    const [aReserve, bReserve] = SundaeUtils.sortSwapAssetsWithAmounts([
+      new AssetAmount(
+        args.swapA.pool.liquidity.aReserve,
+        args.swapA.pool.assetA
+      ),
+      new AssetAmount(
+        args.swapA.pool.liquidity.bReserve,
+        args.swapA.pool.assetB
+      ),
+    ]);
+
+    const { output } = getSwapOutput(
+      swapA.suppliedAsset.amount,
+      aReserve.amount,
+      bReserve.amount,
+      swapA.pool.currentFee
+    );
+    const outputAsset =
+      swapA.suppliedAsset.metadata.assetId === aReserve.metadata.assetId
+        ? bReserve
+        : aReserve;
+
+    const swapB = new SwapConfig({
+      ...args.swapB,
+      suppliedAsset: outputAsset,
+    }).buildArgs();
+
+    const isSecondSwapV1 = swapB.pool.version === EContractVersion.V1;
+
+    const secondSwapBuilder = isSecondSwapV1
+      ? new TxBuilderLucidV1(this.lucid, new DatumBuilderLucidV1(this.network))
+      : this;
+    const secondSwapAddress = isSecondSwapV1
+      ? await secondSwapBuilder
+          .getValidatorScript("escrow.spend")
+          .then(({ compiledCode }) =>
+            this.lucid.utils.validatorToAddress({
+              type: "PlutusV1",
+              script: compiledCode,
+            })
+          )
+      : await (secondSwapBuilder as TxBuilderLucidV3).generateScriptAddress(
+          "order.spend"
+        );
+
+    swapB.suppliedAsset = outputAsset.withAmount(output);
+    const secondSwapData = await secondSwapBuilder.swap({
+      ...swapB,
+      swapType: args.swapB.swapType,
+    });
+
+    let referralFeeAmount = 0n;
+    if (swapA.referralFee) {
+      referralFeeAmount += swapA.referralFee.payment.amount;
+    }
+
+    if (swapB.referralFee) {
+      referralFeeAmount += swapB.referralFee.payment.amount;
+    }
+
+    let mergedReferralFee: ITxBuilderReferralFee | undefined;
+    if (swapA.referralFee) {
+      mergedReferralFee = {
+        ...swapA.referralFee,
+        payment: swapA.referralFee.payment.withAmount(referralFeeAmount),
+      };
+    } else if (swapB.referralFee) {
+      mergedReferralFee = {
+        ...swapB.referralFee,
+        payment: swapB.referralFee.payment.withAmount(referralFeeAmount),
+      };
+    }
+
+    const datumHash = this.lucid.utils.datumToHash(
+      secondSwapData.datum as string
+    );
+
+    const { tx, datum, fees } = await this.swap({
+      ...args.swapA,
+      orderAddresses: {
+        ...args.swapB.orderAddresses,
+        DestinationAddress: {
+          address: secondSwapAddress,
+          datum: {
+            type: isSecondSwapV1 ? EDatumType.HASH : EDatumType.INLINE,
+            value: isSecondSwapV1
+              ? datumHash
+              : (secondSwapData.datum as string),
+          },
+        },
+      },
+      referralFee: mergedReferralFee,
+    });
+
+    if (isSecondSwapV1) {
+      tx.attachMetadataWithConversion(103251, {
+        [`0x${datumHash}`]: SundaeUtils.splitMetadataString(
+          secondSwapData.datum as string,
+          "0x"
+        ),
+      });
+    }
+
+    return this.completeTx({
+      tx,
+      datum,
+      deposit: ORDER_DEPOSIT_DEFAULT * 2n,
+      referralFee: mergedReferralFee?.payment,
+      scooperFee: fees.scooperFee.add(secondSwapData.fees.scooperFee).amount,
     });
   }
 

--- a/packages/core/src/TxBuilders/__tests__/TxBuilder.Lucid.V1.class.test.ts
+++ b/packages/core/src/TxBuilders/__tests__/TxBuilder.Lucid.V1.class.test.ts
@@ -177,7 +177,7 @@ describe("TxBuilderLucidV1", () => {
       }),
     });
 
-    const { builtTx, cbor } = await build();
+    const { builtTx } = await build();
 
     expect(fees.cardanoTxFee).not.toBeUndefined();
 
@@ -248,6 +248,112 @@ describe("TxBuilderLucidV1", () => {
         DatumBuilderLucidV1.INVALID_POOL_IDENT
       );
     }
+  });
+
+  test("orderRouteSwap() - v1 to v1", async () => {
+    const { build, fees } = await builder.orderRouteSwap({
+      swapA: {
+        orderAddresses: {
+          DestinationAddress: {
+            address: PREVIEW_DATA.addresses.current,
+            datum: {
+              type: EDatumType.NONE,
+            },
+          },
+        },
+        swapType: {
+          type: ESwapType.MARKET,
+          slippage: 0.03,
+        },
+        pool: PREVIEW_DATA.pools.v1,
+        suppliedAsset: PREVIEW_DATA.assets.tindy,
+      },
+      swapB: {
+        orderAddresses: {
+          DestinationAddress: {
+            address: PREVIEW_DATA.addresses.current,
+            datum: {
+              type: EDatumType.NONE,
+            },
+          },
+        },
+        swapType: {
+          type: ESwapType.MARKET,
+          slippage: 0.03,
+        },
+        pool: {
+          ...PREVIEW_DATA.pools.v1,
+          ident: "04",
+          assetB: {
+            ...PREVIEW_DATA.pools.v1.assetB,
+            assetId:
+              // iBTC
+              "2fe3c3364b443194b10954771c95819b8d6ed464033c21f03f8facb5.69425443",
+          },
+          assetLP: {
+            ...PREVIEW_DATA.pools.v1.assetLP,
+            assetId:
+              "4086577ed57c514f8e29b78f42ef4f379363355a3b65b9a032ee30c9.6c702004",
+          },
+        },
+      },
+    });
+
+    console.log(fees);
+
+    const { cbor } = await build();
+  });
+
+  test("orderRouteSwap() - v1 to v3", async () => {
+    const { build, fees } = await builder.orderRouteSwap({
+      swapA: {
+        orderAddresses: {
+          DestinationAddress: {
+            address: PREVIEW_DATA.addresses.current,
+            datum: {
+              type: EDatumType.NONE,
+            },
+          },
+        },
+        swapType: {
+          type: ESwapType.MARKET,
+          slippage: 0.03,
+        },
+        pool: PREVIEW_DATA.pools.v1,
+        suppliedAsset: PREVIEW_DATA.assets.tindy,
+      },
+      swapB: {
+        orderAddresses: {
+          DestinationAddress: {
+            address: PREVIEW_DATA.addresses.current,
+            datum: {
+              type: EDatumType.NONE,
+            },
+          },
+        },
+        swapType: {
+          type: ESwapType.MARKET,
+          slippage: 0.03,
+        },
+        pool: {
+          ...PREVIEW_DATA.pools.v3,
+          assetB: {
+            ...PREVIEW_DATA.pools.v3.assetB,
+            assetId:
+              // iBTC
+              "2fe3c3364b443194b10954771c95819b8d6ed464033c21f03f8facb5.69425443",
+          },
+          assetLP: {
+            ...PREVIEW_DATA.pools.v3.assetLP,
+            assetId:
+              "4086577ed57c514f8e29b78f42ef4f379363355a3b65b9a032ee30c9.6c702004",
+          },
+        },
+      },
+    });
+
+    console.log(fees);
+    const { builtTx } = await build();
   });
 
   test("migrateLiquidityToV3() - single migration", async () => {

--- a/packages/core/src/TxBuilders/__tests__/TxBuilder.Lucid.V1.class.test.ts
+++ b/packages/core/src/TxBuilders/__tests__/TxBuilder.Lucid.V1.class.test.ts
@@ -251,16 +251,9 @@ describe("TxBuilderLucidV1", () => {
   });
 
   test("orderRouteSwap() - v1 to v1", async () => {
-    const { build, fees } = await builder.orderRouteSwap({
+    const { build, datum, fees } = await builder.orderRouteSwap({
+      ownerAddress: PREVIEW_DATA.addresses.current,
       swapA: {
-        orderAddresses: {
-          DestinationAddress: {
-            address: PREVIEW_DATA.addresses.current,
-            datum: {
-              type: EDatumType.NONE,
-            },
-          },
-        },
         swapType: {
           type: ESwapType.MARKET,
           slippage: 0.03,
@@ -269,14 +262,6 @@ describe("TxBuilderLucidV1", () => {
         suppliedAsset: PREVIEW_DATA.assets.tindy,
       },
       swapB: {
-        orderAddresses: {
-          DestinationAddress: {
-            address: PREVIEW_DATA.addresses.current,
-            datum: {
-              type: EDatumType.NONE,
-            },
-          },
-        },
         swapType: {
           type: ESwapType.MARKET,
           slippage: 0.03,
@@ -299,22 +284,77 @@ describe("TxBuilderLucidV1", () => {
       },
     });
 
-    console.log(fees);
+    // Deposit carried over = 2 ADA
+    expect(fees.deposit.amount.toString()).toEqual("2000000");
 
-    const { cbor } = await build();
+    // Two swaps = 2.5 + 2.5
+    expect(fees.scooperFee.amount.toString()).toEqual("5000000");
+
+    const { builtTx } = await build();
+
+    let swapOutput: C.TransactionOutput | undefined;
+    [...Array(builtTx.txComplete.body().outputs().len()).keys()].forEach(
+      (index) => {
+        const output = builtTx.txComplete.body().outputs().get(index);
+        const outputHex = output
+          .address()
+          .as_enterprise()
+          ?.payment_cred()
+          .to_scripthash()
+          ?.to_hex();
+
+        if (
+          outputHex ===
+            "730e7d146ad7427a23a885d2141b245d3f8ccd416b5322a31719977e" &&
+          output.amount().multiasset()?.to_js_value()[
+            PREVIEW_DATA.assets.tindy.metadata.assetId.split(".")[0]
+          ][PREVIEW_DATA.assets.tindy.metadata.assetId.split(".")[1]] ===
+            "20000000" &&
+          // deposit (2) + v1 scooper fee (2.5) + v1 scooper fee (2.5) +  = 7
+          output.amount().coin().to_str() === "7000000"
+        ) {
+          swapOutput = output;
+        }
+      }
+    );
+
+    expect(swapOutput).not.toBeUndefined();
+    expect(swapOutput).not.toBeUndefined();
+    const inlineDatum = swapOutput?.datum()?.as_data()?.get().to_bytes();
+
+    expect(inlineDatum).toBeUndefined();
+    expect(swapOutput?.datum()?.as_data_hash()?.to_hex()).toEqual(
+      "3043e2dc62f9e00a9374c71338c67bf3f55173cd11a713a31fa2f55e9a4ed428"
+    );
+
+    const datumBytes = builtTx.txComplete
+      .witness_set()
+      .plutus_data()
+      ?.get(0)
+      .to_bytes();
+    expect(datumBytes).not.toBeUndefined();
+    expect(Buffer.from(datumBytes as Uint8Array).toString("hex")).toEqual(
+      datum
+    );
+
+    const transactionMetadata = builtTx.txComplete
+      .auxiliary_data()
+      ?.metadata()
+      ?.get(C.BigNum.from_str("103251"))
+      ?.as_map();
+
+    expect(transactionMetadata).not.toBeUndefined();
+    expect(
+      Buffer.from(transactionMetadata?.to_bytes() as Uint8Array).toString("hex")
+    ).toEqual(
+      "a158202f046e481ae60ba18b449cda20c7c0878be2aee90ca79bbf3528f21b5478019585581fd8799f4104d8799fd8799fd8799fd8799f581cc279a3fb3b4e62bbc78e2887581f83b58045d4ae82a18867d8352d02775affd8799fd8799fd8799f581c121fd2581f2e0b57ac206fefc763f8bfa0771919f5218b40691eea4514d0ffffffffd87a581f80ffd87a80ff1a002625a0d8799fd879801a021f1b48d8799f1a00f39ad2ff42ffff"
+    );
   });
 
   test("orderRouteSwap() - v1 to v3", async () => {
-    const { build, fees } = await builder.orderRouteSwap({
+    const { build, datum, fees } = await builder.orderRouteSwap({
+      ownerAddress: PREVIEW_DATA.addresses.current,
       swapA: {
-        orderAddresses: {
-          DestinationAddress: {
-            address: PREVIEW_DATA.addresses.current,
-            datum: {
-              type: EDatumType.NONE,
-            },
-          },
-        },
         swapType: {
           type: ESwapType.MARKET,
           slippage: 0.03,
@@ -323,14 +363,6 @@ describe("TxBuilderLucidV1", () => {
         suppliedAsset: PREVIEW_DATA.assets.tindy,
       },
       swapB: {
-        orderAddresses: {
-          DestinationAddress: {
-            address: PREVIEW_DATA.addresses.current,
-            datum: {
-              type: EDatumType.NONE,
-            },
-          },
-        },
         swapType: {
           type: ESwapType.MARKET,
           slippage: 0.03,
@@ -352,8 +384,71 @@ describe("TxBuilderLucidV1", () => {
       },
     });
 
-    console.log(fees);
+    // Deposit carried over = 2 ADA
+    expect(fees.deposit.amount.toString()).toEqual("2000000");
+
+    // Two swaps = 2.5 + .5
+    expect(fees.scooperFee.amount.toString()).toEqual("3000000");
+
     const { builtTx } = await build();
+
+    let swapOutput: C.TransactionOutput | undefined;
+    [...Array(builtTx.txComplete.body().outputs().len()).keys()].forEach(
+      (index) => {
+        const output = builtTx.txComplete.body().outputs().get(index);
+        const outputHex = output
+          .address()
+          .as_enterprise()
+          ?.payment_cred()
+          .to_scripthash()
+          ?.to_hex();
+
+        if (
+          outputHex ===
+            "730e7d146ad7427a23a885d2141b245d3f8ccd416b5322a31719977e" &&
+          output.amount().multiasset()?.to_js_value()[
+            PREVIEW_DATA.assets.tindy.metadata.assetId.split(".")[0]
+          ][PREVIEW_DATA.assets.tindy.metadata.assetId.split(".")[1]] ===
+            "20000000" &&
+          // deposit (2) + v1 scooper fee (2.5) + v3 scooper fee (.5) +  = 5
+          output.amount().coin().to_str() === "5000000"
+        ) {
+          swapOutput = output;
+        }
+      }
+    );
+
+    expect(swapOutput).not.toBeUndefined();
+    expect(swapOutput).not.toBeUndefined();
+    const inlineDatum = swapOutput?.datum()?.as_data()?.get().to_bytes();
+
+    expect(inlineDatum).toBeUndefined();
+    expect(swapOutput?.datum()?.as_data_hash()?.to_hex()).toEqual(
+      "c598c3b1db99083313fce5ae25a4a83b51c0515131f8938c887affdef0ff43d5"
+    );
+
+    const datumBytes = builtTx.txComplete
+      .witness_set()
+      .plutus_data()
+      ?.get(0)
+      .to_bytes();
+    expect(datumBytes).not.toBeUndefined();
+    expect(Buffer.from(datumBytes as Uint8Array).toString("hex")).toEqual(
+      datum
+    );
+
+    const transactionMetadata = builtTx.txComplete
+      .auxiliary_data()
+      ?.metadata()
+      ?.get(C.BigNum.from_str("103251"))
+      ?.as_map();
+
+    expect(transactionMetadata).not.toBeUndefined();
+    expect(
+      Buffer.from(transactionMetadata?.to_bytes() as Uint8Array).toString("hex")
+    ).toEqual(
+      "a15820d165fd2d7150ccc49b8b2580ea4c3948d2538d5cb79e2e91a82d0d77a59e5ced88581fd8799fd8799f581c8bf66e915c450ad94866abb02802821b599e32f43536a4581f2470b21ea2ffd8799f581c121fd22e0b57ac206fefc763f8bfa0771919f521581f8b40691eea4514d0ff1a0007a120d8799fd8799fd8799f581cc279a3fb3b4e581f62bbc78e288783b58045d4ae82a18867d8352d02775affd8799fd8799fd879581f9f581c121fd22e0b57ac206fefc763f8bfa0771919f5218b40691eea4514d0581fffffffffd87980ffd87a9f9f40401a021f1b48ff9f581c2fe3c3364b443194581fb10954771c95819b8d6ed464033c21f03f8facb544694254431a01d7af8aff46ff43d87980ff"
+    );
   });
 
   test("migrateLiquidityToV3() - single migration", async () => {

--- a/packages/core/src/TxBuilders/__tests__/TxBuilder.Lucid.V3.class.test.ts
+++ b/packages/core/src/TxBuilders/__tests__/TxBuilder.Lucid.V3.class.test.ts
@@ -353,16 +353,9 @@ describe("TxBuilderLucidV3", () => {
   });
 
   test("orderRouteSwap() - v3 to v3", async () => {
-    const { build, fees } = await builder.orderRouteSwap({
+    const { build, fees, datum } = await builder.orderRouteSwap({
+      ownerAddress: PREVIEW_DATA.addresses.current,
       swapA: {
-        orderAddresses: {
-          DestinationAddress: {
-            address: PREVIEW_DATA.addresses.current,
-            datum: {
-              type: EDatumType.NONE,
-            },
-          },
-        },
         swapType: {
           type: ESwapType.MARKET,
           slippage: 0.03,
@@ -371,14 +364,6 @@ describe("TxBuilderLucidV3", () => {
         suppliedAsset: PREVIEW_DATA.assets.tindy,
       },
       swapB: {
-        orderAddresses: {
-          DestinationAddress: {
-            address: PREVIEW_DATA.addresses.current,
-            datum: {
-              type: EDatumType.NONE,
-            },
-          },
-        },
         swapType: {
           type: ESwapType.MARKET,
           slippage: 0.03,
@@ -400,20 +385,51 @@ describe("TxBuilderLucidV3", () => {
       },
     });
 
-    const { cbor } = await build();
+    // Deposit carried over = 2 ADA
+    expect(fees.deposit.amount.toString()).toEqual("2000000");
+
+    // Two swaps = .5 + .5
+    expect(fees.scooperFee.amount.toString()).toEqual("1000000");
+
+    const { builtTx, cbor } = await build();
+
+    let swapOutput: C.TransactionOutput | undefined;
+    [...Array(builtTx.txComplete.body().outputs().len()).keys()].forEach(
+      (index) => {
+        const output = builtTx.txComplete.body().outputs().get(index);
+        const outputHex = Buffer.from(
+          output.address().as_base()?.to_address().to_bytes() as Uint8Array
+        ).toString("hex");
+
+        if (
+          outputHex ===
+            "10484969d936f484c45f143d911f81636fe925048e205048ee1fe412aa121fd22e0b57ac206fefc763f8bfa0771919f5218b40691eea4514d0" &&
+          output.amount().multiasset()?.to_js_value()[
+            PREVIEW_DATA.assets.tindy.metadata.assetId.split(".")[0]
+          ][PREVIEW_DATA.assets.tindy.metadata.assetId.split(".")[1]] ===
+            "20000000" &&
+          // deposit (2) + v3 scooper fee (.5) + v3 scooper fee (.5) + 133370 inline datum = 3.133370
+          output.amount().coin().to_str() === "3133370"
+        ) {
+          swapOutput = output;
+        }
+      }
+    );
+
+    expect(swapOutput).not.toBeUndefined();
+    expect(swapOutput).not.toBeUndefined();
+    const inlineDatum = swapOutput?.datum()?.as_data()?.get().to_bytes();
+
+    expect(inlineDatum).not.toBeUndefined();
+    expect(Buffer.from(inlineDatum as Uint8Array).toString("hex")).toEqual(
+      "d8799fd8799f581c8bf66e915c450ad94866abb02802821b599e32f43536a42470b21ea2ffd8799f581c121fd22e0b57ac206fefc763f8bfa0771919f5218b40691eea4514d0ff1a0007a120d8799fd8799fd87a9f581c484969d936f484c45f143d911f81636fe925048e205048ee1fe412aaffd8799fd8799fd8799f581c121fd22e0b57ac206fefc763f8bfa0771919f5218b40691eea4514d0ffffffffd87b9fd8799fd8799f581c8bf66e915c450ad94866abb02802821b599e32f43536a42470b21ea2ffd8799f581c121fd22e0b57ac206fefc763f8bfa0771919f5218b40691eea4514d0ff1a0007a120d8799fd8799fd8799f581cc279a3fb3b4e62bbc78e288783b58045d4ae82a18867d8352d02775affd8799fd8799fd8799f581c121fd22e0b57ac206fefc763f8bfa0771919f5218b40691eea4514d0ffffffffd87980ffd87a9f9f40401a011b5ec7ff9f581c2fe3c3364b443194b10954771c95819b8d6ed464033c21f03f8facb544694254431a00f9f216ffff43d87980ffffffd87a9f9f581cfa3eff2047fdf9293c5feef4dc85ce58097ea1c6da4845a3515351834574494e44591a01312d00ff9f40401a011b5ec7ffff43d87980ff"
+    );
   });
 
   test("orderRouteSwap() - v3 to v1", async () => {
-    const { build, fees } = await builder.orderRouteSwap({
+    const { build, fees, datum } = await builder.orderRouteSwap({
+      ownerAddress: PREVIEW_DATA.addresses.current,
       swapA: {
-        orderAddresses: {
-          DestinationAddress: {
-            address: PREVIEW_DATA.addresses.current,
-            datum: {
-              type: EDatumType.NONE,
-            },
-          },
-        },
         swapType: {
           type: ESwapType.MARKET,
           slippage: 0.03,
@@ -422,14 +438,6 @@ describe("TxBuilderLucidV3", () => {
         pool: PREVIEW_DATA.pools.v3,
       },
       swapB: {
-        orderAddresses: {
-          DestinationAddress: {
-            address: PREVIEW_DATA.addresses.current,
-            datum: {
-              type: EDatumType.NONE,
-            },
-          },
-        },
         swapType: {
           type: ESwapType.MARKET,
           slippage: 0.03,
@@ -452,8 +460,58 @@ describe("TxBuilderLucidV3", () => {
       },
     });
 
-    const { builtTx, cbor } = await build();
-    console.log(cbor);
+    // Deposit carried over = 2 ADA
+    expect(fees.deposit.amount.toString()).toEqual("2000000");
+
+    // Two swaps = .5 + 2.5
+    expect(fees.scooperFee.amount.toString()).toEqual("3000000");
+
+    const { builtTx } = await build();
+
+    let swapOutput: C.TransactionOutput | undefined;
+    [...Array(builtTx.txComplete.body().outputs().len()).keys()].forEach(
+      (index) => {
+        const output = builtTx.txComplete.body().outputs().get(index);
+        const outputHex = Buffer.from(
+          output.address().as_base()?.to_address().to_bytes() as Uint8Array
+        ).toString("hex");
+
+        if (
+          outputHex ===
+            "10484969d936f484c45f143d911f81636fe925048e205048ee1fe412aa121fd22e0b57ac206fefc763f8bfa0771919f5218b40691eea4514d0" &&
+          output.amount().multiasset()?.to_js_value()[
+            PREVIEW_DATA.assets.tindy.metadata.assetId.split(".")[0]
+          ][PREVIEW_DATA.assets.tindy.metadata.assetId.split(".")[1]] ===
+            "20000000" &&
+          // deposit (2) + v3 scooper fee (.5) + v1 scooper fee (2.5) = 5
+          output.amount().coin().to_str() === "5000000"
+        ) {
+          swapOutput = output;
+        }
+      }
+    );
+
+    expect(swapOutput).not.toBeUndefined();
+    expect(swapOutput).not.toBeUndefined();
+    const inlineDatum = swapOutput?.datum()?.as_data()?.get().to_bytes();
+
+    expect(inlineDatum).not.toBeUndefined();
+    expect(Buffer.from(inlineDatum as Uint8Array).toString("hex")).toEqual(
+      "d8799fd8799f581c8bf66e915c450ad94866abb02802821b599e32f43536a42470b21ea2ffd8799f581c121fd22e0b57ac206fefc763f8bfa0771919f5218b40691eea4514d0ff1a0007a120d8799fd8799fd87a9f581c730e7d146ad7427a23a885d2141b245d3f8ccd416b5322a31719977effd87a80ffd87a9f58208d35dd309d5025e51844f3c8b6d6f4e93ec55bf4a85b5c3610860500efc1e9fbffffd87a9f9f581cfa3eff2047fdf9293c5feef4dc85ce58097ea1c6da4845a3515351834574494e44591a01312d00ff9f40401a011b5ec7ffff43d87980ff"
+    );
+
+    const transactionMetadata = builtTx.txComplete
+      .auxiliary_data()
+      ?.metadata()
+      ?.get(C.BigNum.from_str("103251"))
+      ?.as_map();
+
+    expect(transactionMetadata).not.toBeUndefined();
+    expect(
+      Buffer.from(transactionMetadata?.to_bytes() as Uint8Array).toString("hex")
+    ).toEqual(
+      "a158208d35dd309d5025e51844f3c8b6d6f4e93ec55bf4a85b5c3610860500efc1e9fb85581fd8799f4104d8799fd8799fd8799fd8799f581cc279a3fb3b4e62bbc78e2887581f83b58045d4ae82a18867d8352d02775affd8799fd8799fd8799f581c121fd2581f2e0b57ac206fefc763f8bfa0771919f5218b40691eea4514d0ffffffffd87a581f80ffd87a80ff1a002625a0d8799fd879801a011b5ec7d8799f1a00833c12ff42ffff"
+    );
   });
 
   test("deposit()", async () => {

--- a/packages/core/src/TxBuilders/__tests__/TxBuilder.Lucid.V3.class.test.ts
+++ b/packages/core/src/TxBuilders/__tests__/TxBuilder.Lucid.V3.class.test.ts
@@ -352,6 +352,110 @@ describe("TxBuilderLucidV3", () => {
     }
   });
 
+  test("orderRouteSwap() - v3 to v3", async () => {
+    const { build, fees } = await builder.orderRouteSwap({
+      swapA: {
+        orderAddresses: {
+          DestinationAddress: {
+            address: PREVIEW_DATA.addresses.current,
+            datum: {
+              type: EDatumType.NONE,
+            },
+          },
+        },
+        swapType: {
+          type: ESwapType.MARKET,
+          slippage: 0.03,
+        },
+        pool: PREVIEW_DATA.pools.v3,
+        suppliedAsset: PREVIEW_DATA.assets.tindy,
+      },
+      swapB: {
+        orderAddresses: {
+          DestinationAddress: {
+            address: PREVIEW_DATA.addresses.current,
+            datum: {
+              type: EDatumType.NONE,
+            },
+          },
+        },
+        swapType: {
+          type: ESwapType.MARKET,
+          slippage: 0.03,
+        },
+        pool: {
+          ...PREVIEW_DATA.pools.v3,
+          assetB: {
+            ...PREVIEW_DATA.pools.v3.assetB,
+            assetId:
+              // iBTC
+              "2fe3c3364b443194b10954771c95819b8d6ed464033c21f03f8facb5.69425443",
+          },
+          assetLP: {
+            ...PREVIEW_DATA.pools.v3.assetLP,
+            assetId:
+              "4086577ed57c514f8e29b78f42ef4f379363355a3b65b9a032ee30c9.6c702004",
+          },
+        },
+      },
+    });
+
+    const { cbor } = await build();
+  });
+
+  test("orderRouteSwap() - v3 to v1", async () => {
+    const { build, fees } = await builder.orderRouteSwap({
+      swapA: {
+        orderAddresses: {
+          DestinationAddress: {
+            address: PREVIEW_DATA.addresses.current,
+            datum: {
+              type: EDatumType.NONE,
+            },
+          },
+        },
+        swapType: {
+          type: ESwapType.MARKET,
+          slippage: 0.03,
+        },
+        suppliedAsset: PREVIEW_DATA.assets.tindy,
+        pool: PREVIEW_DATA.pools.v3,
+      },
+      swapB: {
+        orderAddresses: {
+          DestinationAddress: {
+            address: PREVIEW_DATA.addresses.current,
+            datum: {
+              type: EDatumType.NONE,
+            },
+          },
+        },
+        swapType: {
+          type: ESwapType.MARKET,
+          slippage: 0.03,
+        },
+        pool: {
+          ...PREVIEW_DATA.pools.v1,
+          ident: "04",
+          assetB: {
+            ...PREVIEW_DATA.pools.v3.assetB,
+            assetId:
+              // iBTC
+              "2fe3c3364b443194b10954771c95819b8d6ed464033c21f03f8facb5.69425443",
+          },
+          assetLP: {
+            ...PREVIEW_DATA.pools.v3.assetLP,
+            assetId:
+              "4086577ed57c514f8e29b78f42ef4f379363355a3b65b9a032ee30c9.6c702004",
+          },
+        },
+      },
+    });
+
+    const { builtTx, cbor } = await build();
+    console.log(cbor);
+  });
+
   test("deposit()", async () => {
     const spiedNewTx = jest.spyOn(builder, "newTxInstance");
     const spiedBuildDepositDatum = jest.spyOn(

--- a/packages/demo/src/components/Actions/Actions.tsx
+++ b/packages/demo/src/components/Actions/Actions.tsx
@@ -17,6 +17,7 @@ import { Deposit } from "./modules/Deposit";
 import { DepositTasteTest } from "./modules/DepositTasteTest";
 import { Lock } from "./modules/LockAssets";
 import { Migrate } from "./modules/MigrateV1LiquidityToV3";
+import { OrderRouting } from "./modules/OrderRouting";
 import { SwapAB } from "./modules/SwapAB";
 import { SwapBA } from "./modules/SwapBA";
 import { Unlock } from "./modules/UnlockAssets";
@@ -128,6 +129,11 @@ export const Actions: FC = () => {
           setCBOR={setCBOR}
           submit={submit}
         />
+        <div className="col-span-2 flex items-center justify-between gap-2">
+          <h4 className="w-32">Order Routing</h4>
+          <hr className="my-10 w-full" />
+        </div>
+        <OrderRouting setFees={setFees} setCBOR={setCBOR} submit={submit} />
       </div>
       {cbor.hash && (
         <>

--- a/packages/demo/src/components/Actions/modules/OrderRouting.tsx
+++ b/packages/demo/src/components/Actions/modules/OrderRouting.tsx
@@ -1,0 +1,201 @@
+import { AssetAmount } from "@sundaeswap/asset";
+import {
+  EContractVersion,
+  EDatumType,
+  ESwapType,
+  IOrderRouteSwapArgs,
+  QueryProviderSundaeSwap,
+  QueryProviderSundaeSwapLegacy,
+} from "@sundaeswap/core";
+import { FC, useCallback, useState } from "react";
+import { IActionArgs, poolQuery } from "../Actions";
+
+import { useAppState } from "../../../state/context";
+import Button from "../../Button";
+
+enum ERoute {
+  V1TOV1 = "V1 to V1",
+  V1TOV3 = "V1 to V3",
+  V3TOV3 = "v3 to V3",
+  V3TOV1 = "v3 to V1",
+}
+
+type TDirection = "forward" | "backward";
+
+export const OrderRouting: FC<IActionArgs> = ({ setCBOR, setFees, submit }) => {
+  const { SDK, ready, activeWalletAddr, useReferral } = useAppState();
+
+  const [direction, setDirection] = useState<TDirection>("forward");
+  const [route, setRoute] = useState<ERoute>(ERoute.V1TOV1);
+  const [swapping, setSwapping] = useState(false);
+
+  const handleSwap = useCallback(async () => {
+    if (!SDK) {
+      return;
+    }
+
+    setSwapping(true);
+    try {
+      const v1PoolTIndy = await new QueryProviderSundaeSwapLegacy(
+        "preview"
+      ).findPoolData(poolQuery);
+      const v1PoolRberry = await new QueryProviderSundaeSwapLegacy(
+        "preview"
+      ).findPoolData({
+        pair: [
+          "",
+          "d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf.524245525259",
+        ],
+        fee: "0.05",
+        ident: "00",
+      });
+      const v3PoolTIndy = await new QueryProviderSundaeSwap(
+        "preview"
+      ).findPoolData({
+        ident: "2e74e6af9739616dd021f547bca1f68c937b566bb6ca2e4782e76001",
+      });
+      const v3PoolRberry = await new QueryProviderSundaeSwap(
+        "preview"
+      ).findPoolData({
+        ident: "bd9437d9ec1a559d053f05dc38d337c32d1d0746952ea961f874c39a",
+      });
+
+      // Determine the appropriate pool for swapA based on the route
+      const swapAPool =
+        route === ERoute.V1TOV1 || route === ERoute.V1TOV3
+          ? v1PoolTIndy
+          : v3PoolTIndy;
+
+      // Determine the appropriate pool for swapB based on the route
+      const swapBPool =
+        route === ERoute.V3TOV3 || route === ERoute.V1TOV3
+          ? v3PoolRberry
+          : v1PoolRberry;
+
+      console.log(swapAPool, swapBPool);
+
+      const args: IOrderRouteSwapArgs = {
+        swapA: {
+          swapType: {
+            type: ESwapType.MARKET,
+            slippage: 0.03,
+          },
+          pool: direction === "forward" ? swapAPool : swapBPool,
+          orderAddresses: {
+            DestinationAddress: {
+              address: activeWalletAddr,
+              datum: {
+                type: EDatumType.NONE,
+              },
+            },
+          },
+          suppliedAsset: new AssetAmount(
+            25000000n,
+            direction === "forward" ? swapAPool.assetB : swapBPool.assetB
+          ),
+        },
+        swapB: {
+          swapType: {
+            type: ESwapType.MARKET,
+            slippage: 0.03,
+          },
+          pool: direction === "forward" ? swapBPool : swapAPool,
+          orderAddresses: {
+            DestinationAddress: {
+              address: activeWalletAddr,
+              datum: {
+                type: EDatumType.NONE,
+              },
+            },
+          },
+        },
+      };
+
+      if (useReferral) {
+        args.swapA.referralFee = {
+          destination:
+            "addr_test1qp6crwxyfwah6hy7v9yu5w6z2w4zcu53qxakk8ynld8fgcpxjae5d7xztgf0vyq7pgrrsk466xxk25cdggpq82zkpdcsdkpc68",
+          payment: new AssetAmount(1000000n, {
+            assetId: "",
+            decimals: 6,
+          }),
+          feeLabel: "Test Fee",
+        };
+
+        args.swapB.referralFee = {
+          destination:
+            "addr_test1qp6crwxyfwah6hy7v9yu5w6z2w4zcu53qxakk8ynld8fgcpxjae5d7xztgf0vyq7pgrrsk466xxk25cdggpq82zkpdcsdkpc68",
+          payment: new AssetAmount(1000000n, {
+            assetId: "",
+            decimals: 6,
+          }),
+          feeLabel: "Test Fee",
+        };
+      }
+
+      await SDK.builder(
+        route === ERoute.V3TOV1 || route === ERoute.V3TOV3
+          ? EContractVersion.V3
+          : EContractVersion.V1
+      )
+        .orderRouteSwap(args)
+        .then(async ({ build, fees }) => {
+          setFees(fees);
+          const builtTx = await build();
+          setCBOR({
+            cbor: builtTx.cbor,
+          });
+
+          if (submit) {
+            const { cbor, submit } = await builtTx.sign();
+            setCBOR({
+              cbor,
+              hash: await submit(),
+            });
+          }
+        });
+    } catch (e) {
+      console.log(e);
+    }
+
+    setSwapping(false);
+  }, [SDK, submit, activeWalletAddr, useReferral, route, direction]);
+
+  if (!SDK) {
+    return null;
+  }
+
+  return (
+    <>
+      <Button disabled={!ready} onClick={handleSwap} loading={swapping}>
+        {direction === "forward"
+          ? "Swap TINDY for RBERRY"
+          : "Swap RBERRY for TINDY"}
+      </Button>
+      <div className="flex justify-between items-center gap-4">
+        <select
+          className="mr-4 w-full rounded-md bg-slate-800 px-4 py-2"
+          value={route}
+          onChange={(e) => {
+            setRoute(e.target.value as ERoute);
+          }}
+        >
+          <option value={ERoute.V1TOV1}>{ERoute.V1TOV1}</option>
+          <option value={ERoute.V1TOV3}>{ERoute.V1TOV3}</option>
+          <option value={ERoute.V3TOV3}>{ERoute.V3TOV3}</option>
+          <option value={ERoute.V3TOV1}>{ERoute.V3TOV1}</option>
+        </select>
+        <select
+          className="mr-4 w-full rounded-md bg-slate-800 px-4 py-2"
+          value={direction}
+          onChange={(e) => {
+            setDirection(e.target.value as TDirection);
+          }}
+        >
+          <option value="forward">TINDY to RBERRY</option>
+          <option value="backward">RBERRY to TINDY</option>
+        </select>
+      </div>
+    </>
+  );
+};


### PR DESCRIPTION
This PR adds support to the V1 and V3 TxBuilders for order routing between them. When given a pair of pools, the SDK will build a transaction that correctly resolves between the two swaps, resulting an A -> B -> C transaction.