### PR TITLE
Feat: Split Fees

### DIFF
--- a/docs/typescript/core/classes/Lucid.DatumBuilderLucidV3.md
+++ b/docs/typescript/core/classes/Lucid.DatumBuilderLucidV3.md
@@ -20,7 +20,7 @@ The current network id.
 
 #### Defined in
 
-[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:91](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L91)
+[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:92](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L92)
 
 ___
 
@@ -32,7 +32,7 @@ The error to throw when the pool ident does not match V1 constraints.
 
 #### Defined in
 
-[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:93](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L93)
+[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:94](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L94)
 
 ## Methods
 
@@ -63,7 +63,7 @@ An object comprising the hash of the inline datum, the inline datum itself,
 
 #### Defined in
 
-[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:158](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L158)
+[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:159](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L159)
 
 ___
 
@@ -90,7 +90,7 @@ An object containing the hash of the inline datum, the inline datum itself,
 
 #### Defined in
 
-[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:249](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L249)
+[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:250](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L250)
 
 ___
 
@@ -118,7 +118,7 @@ An object containing the hash of the inline datum, the inline datum itself,
 
 #### Defined in
 
-[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:297](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L297)
+[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:298](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L298)
 
 ___
 
@@ -148,7 +148,7 @@ An object containing the hash of the inline datum, the inline datum itself,
 
 #### Defined in
 
-[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:114](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L114)
+[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:115](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L115)
 
 ___
 
@@ -179,7 +179,7 @@ An object containing the hash of the inline datum, the inline datum itself,
 
 #### Defined in
 
-[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:203](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L203)
+[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:204](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L204)
 
 ___
 
@@ -201,7 +201,7 @@ Computes the pool ID based on the provided UTxO being spent.
 
 #### Defined in
 
-[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:520](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L520)
+[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:521](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L521)
 
 ___
 
@@ -223,7 +223,7 @@ Computes the pool liquidity name.
 
 #### Defined in
 
-[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:496](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L496)
+[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:497](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L497)
 
 ___
 
@@ -245,7 +245,7 @@ Computes the pool NFT name.
 
 #### Defined in
 
-[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:484](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L484)
+[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:485](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L485)
 
 ___
 
@@ -267,7 +267,7 @@ Computes the pool reference name.
 
 #### Defined in
 
-[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:508](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L508)
+[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:509](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L509)
 
 ___
 
@@ -302,7 +302,7 @@ An object containing the staking and
 
 #### Defined in
 
-[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:551](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L551)
+[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:552](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L552)
 
 ___
 
@@ -331,4 +331,4 @@ The signing key associated with the owner, extracted from the datum. This key is
 
 #### Defined in
 
-[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:590](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L590)
+[packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts:591](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts#L591)

--- a/docs/typescript/core/interfaces/Core.IMintV3PoolConfigArgs.md
+++ b/docs/typescript/core/interfaces/Core.IMintV3PoolConfigArgs.md
@@ -22,4 +22,4 @@ to the SundaeSwap Treasury wallet.
 
 #### Defined in
 
-[packages/core/src/@types/configs.ts:116](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/configs.ts#L116)
+[packages/core/src/@types/configs.ts:121](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/@types/configs.ts#L121)

--- a/packages/core/src/@types/configs.ts
+++ b/packages/core/src/@types/configs.ts
@@ -98,6 +98,11 @@ export interface IWithdrawConfigArgs extends IOrderConfigArgs {
   suppliedLPAsset: AssetAmount<IAssetAmountMetadata>;
 }
 
+export interface IFeesConfig {
+  ask: bigint;
+  bid: bigint;
+}
+
 /**
  * Interface describing the method arguments for creating a pool
  * in the V3 Pool Contract.
@@ -105,7 +110,7 @@ export interface IWithdrawConfigArgs extends IOrderConfigArgs {
 export interface IMintV3PoolConfigArgs extends IBaseConfig {
   assetA: AssetAmount<IAssetAmountMetadata>;
   assetB: AssetAmount<IAssetAmountMetadata>;
-  fee: bigint;
+  fees: bigint | IFeesConfig;
   ownerAddress: string;
   // Defaults to immediately.
   marketOpen?: bigint;

--- a/packages/core/src/Configs/MintV3PoolConfig.class.ts
+++ b/packages/core/src/Configs/MintV3PoolConfig.class.ts
@@ -111,7 +111,7 @@ export class MintV3PoolConfig extends Config<IMintV3PoolConfigArgs> {
 
       if (this.fees.bid > MintV3PoolConfig.MAX_FEE) {
         throw new Error(
-          `Take fee cannot supersede the max fee of ${MintV3PoolConfig.MAX_FEE}.`
+          `Bid fee cannot supersede the max fee of ${MintV3PoolConfig.MAX_FEE}.`
         );
       }
     }

--- a/packages/core/src/Configs/MintV3PoolConfig.class.ts
+++ b/packages/core/src/Configs/MintV3PoolConfig.class.ts
@@ -4,7 +4,7 @@ import { IFeesConfig, IMintV3PoolConfigArgs } from "../@types/index.js";
 import { Config } from "../Abstracts/Config.abstract.class.js";
 
 export class MintV3PoolConfig extends Config<IMintV3PoolConfigArgs> {
-  static MAX_FEE: bigint = 10_000n;
+  static MAX_FEE: bigint = 500n;
 
   assetA?: AssetAmount<IAssetAmountMetadata>;
   assetB?: AssetAmount<IAssetAmountMetadata>;

--- a/packages/core/src/Configs/__tests__/MintV3PoolConfig.class.test.ts
+++ b/packages/core/src/Configs/__tests__/MintV3PoolConfig.class.test.ts
@@ -5,7 +5,7 @@ import { MintV3PoolConfig } from "../MintV3PoolConfig.class.js";
 const defaultArgs: IMintV3PoolConfigArgs = {
   assetA: PREVIEW_DATA.assets.tada,
   assetB: PREVIEW_DATA.assets.tindy,
-  fee: 20n,
+  fees: 20n,
   marketOpen: 0n,
   ownerAddress: "addr_test",
 };
@@ -32,7 +32,10 @@ describe("MintV3PoolConfig class", () => {
       assetB: expect.objectContaining({
         amount: PREVIEW_DATA.assets.tindy.amount,
       }),
-      fee: 20n,
+      fees: {
+        bid: 20n,
+        ask: 20n,
+      },
       marketOpen: 0n,
       ownerAddress: "addr_test",
     });
@@ -42,15 +45,39 @@ describe("MintV3PoolConfig class", () => {
     expect(() =>
       new MintV3PoolConfig({
         ...defaultArgs,
-        fee: 11_000n,
+        fees: 11_000n,
       }).buildArgs()
     ).toThrowError("Fees cannot supersede the max fee of 10000.");
 
     expect(() =>
       new MintV3PoolConfig({
         ...defaultArgs,
-        fee: 10n,
+        fees: 10n,
       }).buildArgs()
     ).not.toThrowError("Fees cannot supersede the max fee of 10000.");
+  });
+
+  it("should fail when an ask fee surpasses the max fee", () => {
+    expect(() =>
+      new MintV3PoolConfig({
+        ...defaultArgs,
+        fees: {
+          bid: 10n,
+          ask: 11_000n,
+        },
+      }).buildArgs()
+    ).toThrowError("Ask fee cannot supersede the max fee of 10000.");
+  });
+
+  it("should fail when a take fee surpasses the max fee", () => {
+    expect(() =>
+      new MintV3PoolConfig({
+        ...defaultArgs,
+        fees: {
+          bid: 11_000n,
+          ask: 10n,
+        },
+      }).buildArgs()
+    ).toThrowError("Take fee cannot supersede the max fee of 10000.");
   });
 });

--- a/packages/core/src/Configs/__tests__/MintV3PoolConfig.class.test.ts
+++ b/packages/core/src/Configs/__tests__/MintV3PoolConfig.class.test.ts
@@ -47,14 +47,18 @@ describe("MintV3PoolConfig class", () => {
         ...defaultArgs,
         fees: 11_000n,
       }).buildArgs()
-    ).toThrowError("Fees cannot supersede the max fee of 10000.");
+    ).toThrowError(
+      `Fees cannot supersede the max fee of ${MintV3PoolConfig.MAX_FEE}.`
+    );
 
     expect(() =>
       new MintV3PoolConfig({
         ...defaultArgs,
         fees: 10n,
       }).buildArgs()
-    ).not.toThrowError("Fees cannot supersede the max fee of 10000.");
+    ).not.toThrowError(
+      `Fees cannot supersede the max fee of ${MintV3PoolConfig.MAX_FEE}.`
+    );
   });
 
   it("should fail when an ask fee surpasses the max fee", () => {
@@ -66,7 +70,9 @@ describe("MintV3PoolConfig class", () => {
           ask: 11_000n,
         },
       }).buildArgs()
-    ).toThrowError("Ask fee cannot supersede the max fee of 10000.");
+    ).toThrowError(
+      `Ask fee cannot supersede the max fee of ${MintV3PoolConfig.MAX_FEE}.`
+    );
   });
 
   it("should fail when a take fee surpasses the max fee", () => {
@@ -78,6 +84,8 @@ describe("MintV3PoolConfig class", () => {
           ask: 10n,
         },
       }).buildArgs()
-    ).toThrowError("Take fee cannot supersede the max fee of 10000.");
+    ).toThrowError(
+      `Take fee cannot supersede the max fee of ${MintV3PoolConfig.MAX_FEE}.`
+    );
   });
 });

--- a/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts
+++ b/packages/core/src/DatumBuilders/DatumBuilder.Lucid.V3.class.ts
@@ -4,6 +4,7 @@ import { C, Constr, Credential, Data, Lucid, UTxO } from "lucid-cardano";
 
 import {
   EDatumType,
+  IFeesConfig,
   TDatumResult,
   TDestinationAddress,
   TSupportedNetworks,
@@ -64,7 +65,7 @@ export interface IDatumBuilderMintPoolV3Args {
   seedUtxo: UTxO;
   assetA: AssetAmount<IAssetAmountMetadata>;
   assetB: AssetAmount<IAssetAmountMetadata>;
-  fee: bigint;
+  fees: IFeesConfig;
   depositFee: bigint;
   marketOpen?: bigint;
 }
@@ -249,7 +250,7 @@ export class DatumBuilderLucidV3 implements DatumBuilder {
   public buildMintPoolDatum({
     assetA,
     assetB,
-    fee,
+    fees,
     marketOpen,
     depositFee,
     seedUtxo,
@@ -265,8 +266,8 @@ export class DatumBuilderLucidV3 implements DatumBuilder {
     const newPoolDatum: V3Types.TPoolDatum = {
       assets: assetsPair,
       circulatingLp: liquidity,
-      bidFeePer10Thousand: fee,
-      askFeePer10Thousand: fee,
+      bidFeePer10Thousand: fees.bid,
+      askFeePer10Thousand: fees.ask,
       feeManager: null,
       identifier: ident,
       marketOpen: marketOpen || 0n,

--- a/packages/core/src/DatumBuilders/__tests__/DatumBuilder.Lucid.V3/buildMintPoolDatum.test.ts
+++ b/packages/core/src/DatumBuilders/__tests__/DatumBuilder.Lucid.V3/buildMintPoolDatum.test.ts
@@ -11,7 +11,10 @@ let builderInstance: DatumBuilderLucidV3;
 const defaultArgs: IDatumBuilderMintPoolV3Args = {
   assetA: PREVIEW_DATA.assets.tada,
   assetB: PREVIEW_DATA.assets.tindy,
-  fee: 5n,
+  fees: {
+    bid: 5n,
+    ask: 5n,
+  },
   marketOpen: 123n,
   depositFee: 2_000_000n,
   seedUtxo: {
@@ -58,6 +61,37 @@ describe("builderMintPoolDatum()", () => {
     expect(spiedOnBuildLexicographicalAssetsDatum).toHaveBeenCalledTimes(1);
     expect(inline).toEqual(
       "d8799f581c82f70fd1663b2b6f4250d6054fe4cac8c815d9eef8b38f68bbe22c929f9f4040ff9f581cfa3eff2047fdf9293c5feef4dc85ce58097ea1c6da4845a3515351834574494e4459ffff1a01312d000505d87a80187b1a001e8480ff"
+    );
+  });
+
+  it("should build the pool mint datum properly with split fees", () => {
+    const spiedOnComputePoolId = jest.spyOn(
+      DatumBuilderLucidV3,
+      "computePoolId"
+    );
+    const spiedOnBuildLexicographicalAssetsDatum = jest.spyOn(
+      DatumBuilderLucidV3.prototype,
+      "buildLexicographicalAssetsDatum"
+    );
+    const expectedIdent =
+      "82f70fd1663b2b6f4250d6054fe4cac8c815d9eef8b38f68bbe22c92";
+
+    const { inline } = builderInstance.buildMintPoolDatum({
+      ...defaultArgs,
+      fees: {
+        ask: 87n,
+        bid: 100n,
+      },
+    });
+
+    expect(spiedOnComputePoolId).toHaveBeenNthCalledWith(
+      1,
+      defaultArgs.seedUtxo
+    );
+    expect(spiedOnComputePoolId).toHaveNthReturnedWith(1, expectedIdent);
+    expect(spiedOnBuildLexicographicalAssetsDatum).toHaveBeenCalledTimes(1);
+    expect(inline).toEqual(
+      "d8799f581c82f70fd1663b2b6f4250d6054fe4cac8c815d9eef8b38f68bbe22c929f9f4040ff9f581cfa3eff2047fdf9293c5feef4dc85ce58097ea1c6da4845a3515351834574494e4459ffff1a01312d0018641857d87a80187b1a001e8480ff"
     );
   });
 });

--- a/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts
+++ b/packages/core/src/TxBuilders/TxBuilder.Lucid.V3.class.ts
@@ -290,7 +290,7 @@ export class TxBuilderLucidV3 extends TxBuilder {
     const {
       assetA,
       assetB,
-      fee,
+      fees,
       marketOpen,
       ownerAddress,
       referralFee,
@@ -348,7 +348,7 @@ export class TxBuilderLucidV3 extends TxBuilder {
     } = this.datumBuilder.buildMintPoolDatum({
       assetA: sortedAssets[0],
       assetB: sortedAssets[1],
-      fee,
+      fees,
       marketOpen,
       depositFee: POOL_MIN_ADA,
       seedUtxo: userUtxos[0],

--- a/packages/core/src/TxBuilders/__tests__/TxBuilder.Lucid.V3.class.test.ts
+++ b/packages/core/src/TxBuilders/__tests__/TxBuilder.Lucid.V3.class.test.ts
@@ -737,7 +737,7 @@ describe("TxBuilderLucidV3", () => {
     const { fees, build } = await builder.mintPool({
       assetA: PREVIEW_DATA.assets.tada,
       assetB: PREVIEW_DATA.assets.tindy,
-      fee: 5n,
+      fees: 5n,
       marketOpen: 5n,
       ownerAddress: PREVIEW_DATA.addresses.current,
     });
@@ -856,7 +856,7 @@ describe("TxBuilderLucidV3", () => {
     const { fees, build } = await builder.mintPool({
       assetA: PREVIEW_DATA.assets.tada,
       assetB: PREVIEW_DATA.assets.tindy,
-      fee: 5n,
+      fees: 5n,
       marketOpen: 5n,
       ownerAddress: PREVIEW_DATA.addresses.current,
       donateToTreasury: 100n,
@@ -979,7 +979,7 @@ describe("TxBuilderLucidV3", () => {
     const { fees, build } = await builder.mintPool({
       assetA: PREVIEW_DATA.assets.tada,
       assetB: PREVIEW_DATA.assets.tindy,
-      fee: 5n,
+      fees: 5n,
       marketOpen: 5n,
       ownerAddress: PREVIEW_DATA.addresses.current,
       donateToTreasury: 43n,
@@ -1127,7 +1127,7 @@ describe("TxBuilderLucidV3", () => {
     const { fees, build } = await builder.mintPool({
       assetA: PREVIEW_DATA.assets.tindy,
       assetB: PREVIEW_DATA.assets.usdc,
-      fee: 5n,
+      fees: 5n,
       marketOpen: 5n,
       ownerAddress: PREVIEW_DATA.addresses.current,
     });
@@ -1254,7 +1254,7 @@ describe("TxBuilderLucidV3", () => {
       await builder.mintPool({
         assetA: PREVIEW_DATA.assets.tada.withAmount(500_000n),
         assetB: PREVIEW_DATA.assets.usdc,
-        fee: 5n,
+        fees: 5n,
         marketOpen: 5n,
         ownerAddress: PREVIEW_DATA.addresses.current,
       });
@@ -1272,7 +1272,7 @@ describe("TxBuilderLucidV3", () => {
       await builder.mintPool({
         assetA: PREVIEW_DATA.assets.tada,
         assetB: PREVIEW_DATA.assets.tindy,
-        fee: 5n,
+        fees: 5n,
         marketOpen: 5n,
         ownerAddress: PREVIEW_DATA.addresses.current,
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1934,13 +1934,6 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@sundaeswap/asset@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@sundaeswap/asset/-/asset-0.7.1.tgz#5a05c67fc0badf2a08a1f1f22260377c5039a44f"
-  integrity sha512-V6DZiLr5WTRA1J/6tBDBZGOq74Szl+dtnfinubhaIHSgqByM9EAN3ech9R8gp9zTRwBIO5puXp9UuQCO4KhOVQ==
-  dependencies:
-    "@sundaeswap/fraction" "^0.5.9"
-
 "@sundaeswap/asset@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@sundaeswap/asset/-/asset-1.0.3.tgz#920bcad43dd51ee9da231a975b5c9f5e321e8bea"
@@ -1975,11 +1968,6 @@
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@sundaeswap/fraction/-/fraction-1.0.3.tgz#bfc51923da05581e3122eee0d4802275878349e3"
   integrity sha512-LP4ag3R8nIHQo99ijNsWLYzun9k4sFvvTVt4swFeGwCntPQVXxGyHLqT98kV5/KT1Ny9w9XH6fdWqZsxMcv4aQ==
-
-"@sundaeswap/fraction@^0.5.9":
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/@sundaeswap/fraction/-/fraction-0.5.9.tgz#cd97f453bee9b9933ec98d1287fdeca28ea6cdb8"
-  integrity sha512-3KamPkKlXj6oLY1NNb4QjwKc0p+2MUthEGbFl4S9hf7qdxH5HWE4itcbsMpLOmEHWWy1N3fzUffuVkPWsyddZg==
 
 "@swc/core-darwin-arm64@1.4.1":
   version "1.4.1"


### PR DESCRIPTION
This PR adds support for split fees when minting a pool. This means that a user can define a custom bid/ask fee for their pool. Backwards compatible, this allows a shortcut to set both the bid/ask with one value, and is the default notation.