### PR TITLE
fix: add signer keys from datum in v1

### DIFF
--- a/docs/typescript/core/Blaze/classes/TxBuilderBlazeV1.md
+++ b/docs/typescript/core/Blaze/classes/TxBuilderBlazeV1.md
@@ -41,7 +41,7 @@ The network id to use when building the transaction.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:101](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L101)
+[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:110](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L110)
 
 ## Properties
 
@@ -53,7 +53,7 @@ A configured Blaze instance to use.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:102](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L102)
+[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:111](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L111)
 
 ## Methods
 
@@ -79,7 +79,7 @@ The parameter you want to retrieve.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:243](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L243)
+[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:252](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L252)
 
 ***
 
@@ -119,7 +119,7 @@ const txHash = await sdk.builder().cancel({
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:576](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L576)
+[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:582](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L582)
 
 ***
 
@@ -140,7 +140,7 @@ will re-populate with real data.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:188](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L188)
+[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:197](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L197)
 
 ***
 
@@ -164,7 +164,7 @@ The name of the validator script to retrieve.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:207](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L207)
+[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:216](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L216)
 
 ***
 
@@ -233,7 +233,7 @@ const migrationResult = await sdk.builder().migrateLiquidityToV3([
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:1106](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L1106)
+[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:1136](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L1136)
 
 ***
 
@@ -257,7 +257,7 @@ Returns a new Tx instance from Blaze. Throws an error if not ready.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:253](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L253)
+[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:262](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L262)
 
 ***
 
@@ -285,7 +285,7 @@ The result of the transaction.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:415](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L415)
+[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:421](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L421)
 
 ***
 
@@ -325,7 +325,7 @@ const txHash = await sdk.builder().swap({
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:329](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L329)
+[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:335](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L335)
 
 ***
 
@@ -376,7 +376,7 @@ const txHash = await sdk.builder().update({
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:682](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L682)
+[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:712](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L712)
 
 ***
 
@@ -416,7 +416,7 @@ const txHash = await sdk.builder().withdraw({
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:847](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L847)
+[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:877](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L877)
 
 ***
 
@@ -456,7 +456,7 @@ const txHash = await sdk.builder().zap({
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:915](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L915)
+[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:945](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L945)
 
 ***
 
@@ -486,4 +486,4 @@ The protocol network.
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:230](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L230)
+[packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts:239](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Blaze.V1.class.ts#L239)

--- a/docs/typescript/core/Lucid/classes/TxBuilderLucidV1.md
+++ b/docs/typescript/core/Lucid/classes/TxBuilderLucidV1.md
@@ -233,7 +233,7 @@ const migrationResult = await sdk.builder().migrateLiquidityToV3([
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:913](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L913)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:919](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L919)
 
 ***
 
@@ -376,7 +376,7 @@ const txHash = await sdk.builder().update({
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:550](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L550)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:556](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L556)
 
 ***
 
@@ -416,7 +416,7 @@ const txHash = await sdk.builder().withdraw({
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:689](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L689)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:695](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L695)
 
 ***
 
@@ -456,7 +456,7 @@ const txHash = await sdk.builder().zap({
 
 #### Defined in
 
-[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:745](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L745)
+[packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts:751](https://github.com/SundaeSwap-finance/sundae-sdk/blob/main/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts#L751)
 
 ***
 

--- a/packages/core/src/@types/configs.ts
+++ b/packages/core/src/@types/configs.ts
@@ -78,7 +78,7 @@ export interface IDepositConfigArgs extends IOrderConfigArgs {
  * The arguments configuration for building a valid cancellation transaction.
  */
 export interface ICancelConfigArgs extends IBaseConfig {
-  ownerAddress: string;
+  ownerAddress?: string;
   utxo: TUTXO;
 }
 

--- a/packages/core/src/Configs/CancelConfig.class.ts
+++ b/packages/core/src/Configs/CancelConfig.class.ts
@@ -35,7 +35,7 @@ export class CancelConfig extends OrderConfig<ICancelConfigArgs> {
 
   setFromObject({ utxo, ownerAddress, referralFee }: ICancelConfigArgs): void {
     this.setUTXO(utxo);
-    this.setOwnerAddress(ownerAddress);
+    ownerAddress && this.setOwnerAddress(ownerAddress);
     referralFee && this.setReferralFee(referralFee);
   }
 
@@ -43,12 +43,6 @@ export class CancelConfig extends OrderConfig<ICancelConfigArgs> {
     if (!this.utxo) {
       throw new Error(
         "You did not add the order's UTXO for this cancellation. Set a valid UTXO with .setUTXO()",
-      );
-    }
-
-    if (!this.ownerAddress) {
-      throw new Error(
-        "An owner address is required for validation purposes. Set the owner address of the order with .setOwnerAddress()",
       );
     }
   }

--- a/packages/core/src/DatumBuilders/ContractTypes/Contract.Blaze.v1.ts
+++ b/packages/core/src/DatumBuilders/ContractTypes/Contract.Blaze.v1.ts
@@ -109,6 +109,20 @@ export const WithdrawAssetSchema = Data.Enum([
 export type TWithdrawAsset = Static<typeof WithdrawAssetSchema>;
 export const WithdrawAsset = WithdrawAssetSchema as unknown as TWithdrawAsset;
 
+/**
+ * @todo
+ * The WithdrawAsset is using an enum that can be consolidated like V3 orders.
+ * This will help simplify checking order datums with a single type.
+ *
+ * - OrderSchema
+ * -- ident
+ * -- orderAddresses
+ * -- scooperFee
+ * -- details (enum)
+ * --- Swap (121)
+ * --- Withdraw (122)
+ * --- Deposit (123)
+ */
 export const WithdrawOrderSchema = Data.Object({
   ident: Data.Bytes(),
   orderAddresses: OrderAddressesSchema,

--- a/packages/core/src/DatumBuilders/ContractTypes/Contract.Blaze.v1.ts
+++ b/packages/core/src/DatumBuilders/ContractTypes/Contract.Blaze.v1.ts
@@ -1,16 +1,24 @@
 import { Data, Static } from "@blaze-cardano/sdk";
 
+export const KeyHashSchema = Data.Object({
+  KeyHash: Data.Object({
+    value: Data.Bytes(),
+  }),
+});
+export type TKeyHashSchema = Static<typeof KeyHashSchema>;
+export const KeyHash = KeyHashSchema as unknown as TKeyHashSchema;
+
+export const ScriptHashSchema = Data.Object({
+  ScriptHash: Data.Object({
+    value: Data.Bytes(),
+  }),
+});
+export type TScriptHashSchema = Static<typeof ScriptHashSchema>;
+export const ScriptHash = ScriptHashSchema as unknown as TScriptHashSchema;
+
 export const PaymentStakingHashSchema = Data.Enum([
-  Data.Object({
-    KeyHash: Data.Object({
-      value: Data.Bytes(),
-    }),
-  }),
-  Data.Object({
-    ScriptHash: Data.Object({
-      value: Data.Bytes(),
-    }),
-  }),
+  KeyHashSchema,
+  ScriptHashSchema,
 ]);
 export type TPaymentStakingHash = Static<typeof PaymentStakingHashSchema>;
 export const PaymentStakingHash =

--- a/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts
+++ b/packages/core/src/TxBuilders/TxBuilder.Lucid.V1.class.ts
@@ -452,6 +452,12 @@ export class TxBuilderLucidV1 extends TxBuilderV1 {
       cancelArgs,
     ).buildArgs();
 
+    if (!ownerAddress) {
+      throw new Error(
+        "An owner address is required to be explicitly supplied when using the Lucid builder.",
+      );
+    }
+
     const tx = this.newTxInstance(referralFee);
     const utxosToSpend = await this.lucid.provider.getUtxosByOutRef([
       { outputIndex: utxo.index, txHash: utxo.hash },

--- a/packages/core/src/TxBuilders/__tests__/TxBuilder.Blaze.V1.class.test.ts
+++ b/packages/core/src/TxBuilders/__tests__/TxBuilder.Blaze.V1.class.test.ts
@@ -67,19 +67,14 @@ describe("TxBuilderBlazeV1", () => {
     const txWithReferralAndLabel = builder.newTxInstance({
       destination: TEST_REFERRAL_DEST,
       payment: new AssetAmount(1_500_000n, ADA_METADATA),
-      // feeLabel: "Test Label",
+      feeLabel: "Test Label",
     });
 
     const txComplete = await txWithReferralAndLabel.complete();
-    // const metadata = txComplete.auxiliaryData()?.metadata();
+    const metadata = txComplete.auxiliaryData()?.metadata()?.metadata();
 
-    /**
-     * @TODO Restore this once Blaze fixes metadata bug.
-     */
-    // expect(metadata).not.toBeUndefined();
-    // expect(metadata?.metadata()?.get(674n)?.asText()).toEqual(
-    //   "Test Label: 1.5 ADA"
-    // );
+    expect(metadata).not.toBeUndefined();
+    expect(metadata?.get(674n)?.asText()).toEqual("Test Label: 1.5 ADA");
 
     let referralAddressOutput: Core.TransactionOutput | undefined;
     [...Array(txComplete.body().outputs().length).keys()].forEach((index) => {
@@ -1100,7 +1095,6 @@ describe("TxBuilderBlazeV1", () => {
     );
 
     const { build, datum, fees } = await builder.cancel({
-      ownerAddress: PREVIEW_DATA.addresses.current,
       utxo: {
         hash: PREVIEW_DATA.wallet.submittedOrderUtxos.swapV1.txHash,
         index: PREVIEW_DATA.wallet.submittedOrderUtxos.swapV1.outputIndex,
@@ -1119,7 +1113,7 @@ describe("TxBuilderBlazeV1", () => {
       }),
     } as ITxBuilderFees);
 
-    const { builtTx } = await build();
+    const { builtTx, cbor } = await build();
 
     expect(
       builtTx
@@ -1176,7 +1170,6 @@ describe("TxBuilderBlazeV1", () => {
     // Don't care to mock v3 so it will throw.
     try {
       await builder.cancel({
-        ownerAddress: PREVIEW_DATA.addresses.current,
         utxo: {
           hash: PREVIEW_DATA.wallet.submittedOrderUtxos.swapV3.txHash,
           index: PREVIEW_DATA.wallet.submittedOrderUtxos.swapV3.outputIndex,

--- a/packages/core/src/TxBuilders/__tests__/TxBuilder.Blaze.V3.class.test.ts
+++ b/packages/core/src/TxBuilders/__tests__/TxBuilder.Blaze.V3.class.test.ts
@@ -196,7 +196,6 @@ describe("TxBuilderBlazeV3", () => {
     );
 
     const { build, fees } = await builder.cancel({
-      ownerAddress: PREVIEW_DATA.addresses.current,
       utxo: {
         hash: "b18feb718648b33ef4900519b76f72f46723577ebad46191e2f8e1076c2b632c",
         index: 0,
@@ -283,7 +282,6 @@ describe("TxBuilderBlazeV3", () => {
     // Don't care to mock v3 so it will throw.
     try {
       await builder.cancel({
-        ownerAddress: PREVIEW_DATA.addresses.current,
         utxo: {
           hash: PREVIEW_DATA.wallet.submittedOrderUtxos.swapV1.txHash,
           index: PREVIEW_DATA.wallet.submittedOrderUtxos.swapV1.outputIndex,

--- a/packages/yield-farming/src/lib/TxBuilders/__tests__/TxBuilder.YieldFarming.Blaze.class.test.ts
+++ b/packages/yield-farming/src/lib/TxBuilders/__tests__/TxBuilder.YieldFarming.Blaze.class.test.ts
@@ -398,7 +398,6 @@ describe("YieldFarmingBlaze", () => {
       ),
     );
 
-    console.log(tx.builtTx.body().toCbor());
     const outputWithAssets = tx.builtTx
       .body()
       .outputs()


### PR DESCRIPTION
Signer keys were assuming that the wallet credentials were the same as the order being cancelled. This caused problems when the person used a multi-address wallet, where they might try cancelling an order using a payment credential that was different than the one used to place the order.

This grabs the real payment and staking credentials from the datum in V1 contracts so that the transaction being built is valid for the contract.