### PR TITLE
Fix: `isLPAsset`

### DIFF
--- a/.changeset/loose-laws-join.md
+++ b/.changeset/loose-laws-join.md
@@ -1,0 +1,5 @@
+---
+"@sundaeswap/core": patch
+---
+
+Updates the `isLPAsset` function to more strictly check v3 LP tokens.

--- a/packages/core/src/Utilities/__tests__/SundaeUtils.class.test.ts
+++ b/packages/core/src/Utilities/__tests__/SundaeUtils.class.test.ts
@@ -24,6 +24,18 @@ const mockedProtocols: ISundaeProtocolParams[] = [
     references: [],
     version: EContractVersion.V1,
   },
+  {
+    blueprint: {
+      validators: [
+        {
+          hash: "e0302560ced2fdcbfcb2602697df970cd0d6a38f94b32703f51c312b",
+          title: "pool.mint",
+        },
+      ],
+    },
+    references: [],
+    version: EContractVersion.V3,
+  },
 ];
 
 describe("SundaeUtils class", () => {
@@ -372,22 +384,47 @@ describe("SundaeUtils class", () => {
   describe("isLPAsset", () => {
     it("should return true for a matching LP asset policy ID", () => {
       const result = SundaeUtils.isLPAsset({
-        assetPolicyId:
-          "4086577ed57c514f8e29b78f42ef4f379363355a3b65b9a032ee30c9",
+        assetId:
+          "4086577ed57c514f8e29b78f42ef4f379363355a3b65b9a032ee30c9.exampleAssetName",
         protocols: mockedProtocols,
         version: EContractVersion.V1,
+      });
+      expect(result).toBe(true);
+
+      const result2 = SundaeUtils.isLPAsset({
+        assetId:
+          "e0302560ced2fdcbfcb2602697df970cd0d6a38f94b32703f51c312b.0014df100101",
+        protocols: mockedProtocols,
+        version: EContractVersion.V3,
       });
       expect(result).toBe(true);
     });
 
     it("should return false for a non-matching LP asset policy ID", () => {
       const result = SundaeUtils.isLPAsset({
-        assetPolicyId: "123",
+        assetId: "123.exampleAssetName",
         protocols: mockedProtocols,
         version: EContractVersion.V1,
       });
       expect(result).toBe(false);
+
+      const result2 = SundaeUtils.isLPAsset({
+        assetId:
+          "e0302560ced2fdcbfcb2602697df970cd0d6a38f94b32703f51c312b.0101",
+        protocols: mockedProtocols,
+        version: EContractVersion.V3,
+      });
+      expect(result).toBe(false);
     });
+
+    it("should error if no matching protocol is found for the version type", () => {
+      expect(() => SundaeUtils.isLPAsset({
+        assetId: "exampleasset.id",
+        protocols: mockedProtocols,
+        // @ts-expect-error Random version to ensure it can't find a matching protocol.
+        version: "V4"
+      })).toThrowError("Could not find a matching protocol for this version.")
+    })
   });
 
   describe("isAssetIdsEqual", () => {


### PR DESCRIPTION
This PR more strictly checks v3 LP assets to also include their asset name prefix. Otherwise, CIP-68 metadata tokens also show up in the user's liquidity tab.