### PR TITLE
prevent overwriting asset map for exotic pool

### DIFF
--- a/.changeset/gold-singers-sip.md
+++ b/.changeset/gold-singers-sip.md
@@ -1,0 +1,5 @@
+---
+"@sundaeswap/core": patch
+---
+
+Fix coin selection for exotic pool minting.

--- a/bun.lock
+++ b/bun.lock
@@ -30,13 +30,13 @@
     },
     "packages/cli": {
       "name": "@sundaeswap/cli",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "bin": "./dist/cli/index.js",
       "dependencies": {
         "@blaze-cardano/sdk": "0.2.27",
         "@inquirer/prompts": "^7.5.0",
         "@sundaeswap/asset": "^1.0.7",
-        "@sundaeswap/core": "^2.5.0",
+        "@sundaeswap/core": "^2.6.0",
         "asciify-image": "^0.1.10",
         "clipboardy": "^4.0.0",
       },
@@ -50,7 +50,7 @@
     },
     "packages/core": {
       "name": "@sundaeswap/core",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "devDependencies": {
         "@blaze-cardano/emulator": "^0.3.28",
         "@sundaeswap/bigint-math": "^0.6.3",
@@ -76,7 +76,7 @@
         "@blaze-cardano/sdk": "^0.2.27",
         "@sundaeswap/asset": "^1.0.3",
         "@sundaeswap/bigint-math": "^0.6.3",
-        "@sundaeswap/core": "^2.5.0",
+        "@sundaeswap/core": "^2.6.0",
         "@sundaeswap/cpp": "^1.0.3",
         "@sundaeswap/fraction": "^1.0.3",
         "@sundaeswap/taste-test": "^3.0.1",
@@ -160,7 +160,7 @@
     },
     "packages/yield-farming": {
       "name": "@sundaeswap/yield-farming",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "devDependencies": {
         "@blaze-cardano/emulator": "^0.3.21",
         "@sundaeswap/core": "workspace:*",
@@ -4330,7 +4330,7 @@
 
     "@semantic-release/release-notes-generator/get-stream": ["get-stream@7.0.1", "", {}, "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ=="],
 
-    "@sundaeswap/cli/@types/bun": ["@types/bun@1.2.18", "", { "dependencies": { "bun-types": "1.2.18" } }, "sha512-Xf6RaWVheyemaThV0kUfaAUvCNokFr+bH8Jxp+tTZfx7dAPA8z9ePnP9S9+Vspzuxxx9JRAXhnyccRj3GyCMdQ=="],
+    "@sundaeswap/cli/@types/bun": ["@types/bun@1.2.19", "", { "dependencies": { "bun-types": "1.2.19" } }, "sha512-d9ZCmrH3CJ2uYKXQIUuZ/pUnTqIvLDS0SK7pFmbx8ma+ziH/FRMoAq5bYpRG7y+w1gl+HgyNZbtqgMq4W4e2Lg=="],
 
     "@sundaeswap/eslint-config/globals": ["globals@15.14.0", "", {}, "sha512-OkToC372DtlQeje9/zHIo5CT8lRP/FUgEOKBEhU4e0abL7J7CD24fD9ohiLN5hagG/kWCYj4K5oaxxtj2Z0Dig=="],
 
@@ -5876,7 +5876,7 @@
 
     "@semantic-release/release-notes-generator/conventional-commits-parser/meow": ["meow@13.2.0", "", {}, "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA=="],
 
-    "@sundaeswap/cli/@types/bun/bun-types": ["bun-types@1.2.18", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-04+Eha5NP7Z0A9YgDAzMk5PHR16ZuLVa83b26kH5+cp1qZW4F6FmAURngE7INf4tKOvCE69vYvDEwoNl1tGiWw=="],
+    "@sundaeswap/cli/@types/bun/bun-types": ["bun-types@1.2.19", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-uAOTaZSPuYsWIXRpj7o56Let0g/wjihKCkeRqUBhlLVM/Bt+Fj9xTo+LhC1OV1XDaGkz4hNC80et5xgy+9KTHQ=="],
 
     "@testing-library/dom/pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/packages/core/src/TxBuilders/TxBuilder.V3.class.ts
+++ b/packages/core/src/TxBuilders/TxBuilder.V3.class.ts
@@ -1314,15 +1314,15 @@ export class TxBuilderV3 extends TxBuilderAbstractV3 {
   ): Promise<Core.TransactionUnspentOutput[]> {
     const utxos = await this.blaze.wallet.getUnspentOutputs();
     const neededValue = new Core.Value(5_000_000n); // Start with a 5 ADA requirement to cover fee and minting costs.
+    const multiAsset = new Map<Core.AssetId, bigint>();
     requiredAssets.forEach((asset) => {
       if (SundaeUtils.isAdaAsset(asset.metadata)) {
         neededValue.setCoin(asset.amount);
       } else {
-        neededValue.setMultiasset(
-          new Map([[Core.AssetId(asset.metadata.assetId), asset.amount]]),
-        );
+        multiAsset.set(Core.AssetId(asset.metadata.assetId), asset.amount);
       }
     });
+    neededValue.setMultiasset(multiAsset);
 
     const chosenUtxos = CoinSelector.micahsSelector(
       utxos,


### PR DESCRIPTION
When minting an exotic pool the second asset overwrites the first asset when constructing the neededvalue for utxo selection. If the user does not have both assets in the same utxo we risk the first asset to be missing in the inputs and the tx building to fail.