### PR TITLE
fix(core): explicit ESM specifiers so plain-Node ESM can import @sundaeswap/core

### DIFF
--- a/packages/core/src/Configs/StrategyConfig.class.ts
+++ b/packages/core/src/Configs/StrategyConfig.class.ts
@@ -6,7 +6,7 @@ import {
   IStrategyConfigInputArgs,
   TDestination,
   TDestinationFixed,
-} from "../@types";
+} from "../@types/index.js";
 import { Config } from "../Abstracts/Config.abstract.class.js";
 
 export class StrategyConfig extends Config<IStrategyConfigArgs> {

--- a/packages/core/src/TestUtilities/mocks.ts
+++ b/packages/core/src/TestUtilities/mocks.ts
@@ -7,7 +7,7 @@
  */
 
 import { beforeEach, mock, type Mock } from "bun:test";
-import * as Core from "../exports/core";
+import * as Core from "../exports/core.js";
 
 export const MockAll = () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Importing `@sundaeswap/core` under plain Node ESM (`"type": "module"`, no bundler) currently fails:

```
node -e "import('@sundaeswap/core')"
# Error [ERR_UNSUPPORTED_DIR_IMPORT]: Directory import '…/dist/esm/@types' is not supported
# resolving ES modules imported from …/dist/esm/Configs/StrategyConfig.class.js
```

**Cause:** the ESM build emits import specifiers verbatim, and Node's ESM resolver does no directory resolution or extension guessing. Two files use directory/extensionless relative imports, while the rest of the package consistently writes explicit `/index.js` / `.js` specifiers:

- `Configs/StrategyConfig.class.ts` — `from "../@types"`. This breaks the **main entry**: `dist/esm/exports/core.js` transitively loads `StrategyConfig.class.js`, so any plain-Node ESM import of the package throws.
- `TestUtilities/mocks.ts` — `from "../exports/core"`. Same class of issue, latent on the `./testing` entry (`ERR_MODULE_NOT_FOUND`).

CJS, Bun, and bundlers all do their own directory/extension resolution, which is why this has gone unnoticed.

**Fix:** make both specifiers explicit, matching the existing style everywhere else in the package (e.g. `SundaeSDK.class.ts`, `Configs/SwapConfig.class.ts`). No behavior change for any currently-working consumer.

Left to maintainers: version bump/changeset as you prefer, and optionally `"moduleResolution": "node16"`/`"nodenext"` in the core tsconfig would make `tsc` catch this class of specifier at build time.

Found while integrating `@sundaeswap/core` downstream in RealFi's partner SDK, where plain-Node ESM is currently documented as a known-broken runtime because of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)