### PR TITLE
fix(core): publish current math workspace version

### DIFF
--- a/.changeset/curvy-pools-pack.md
+++ b/.changeset/curvy-pools-pack.md
@@ -1,0 +1,6 @@
+---
+"@sundaeswap/core": patch
+---
+
+Fix the published `@sundaeswap/math` dependency so Core includes the pool math
+exports it imports.

--- a/bun.lock
+++ b/bun.lock
@@ -147,7 +147,7 @@
     },
     "packages/math": {
       "name": "@sundaeswap/math",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "devDependencies": {
         "@types/bun": "latest",
       },


### PR DESCRIPTION
## What changed

- sync the `@sundaeswap/math` workspace version in `bun.lock` from `0.2.2` to
  the already-released `0.3.0`
- add a patch changeset for `@sundaeswap/core`

The existing CI and publishing commands are unchanged.

## Why

`@sundaeswap/core@2.13.0` imports `ConstantSumPool` and
`ConcentratedLiquidityPool`, which were released in `@sundaeswap/math@0.3.0`.
The source dependency is `workspace:*`, but the workspace metadata in
`bun.lock` still recorded Math `0.2.2`. `bun publish` therefore rewrote the
published Core manifest to an exact `@sundaeswap/math@0.2.2` dependency.

As a result, a clean ESM import of Core `2.13.0` fails because those exports do
not exist in Math `0.2.2`. The patch changeset republishes Core with the correct
Math dependency.

## Validation

- `bun run build`
- `bun test`: 432 passed, 3 skipped, 0 failed
- simulated the existing unchanged Changesets release flow in an isolated
  worktree
- the resulting packed Core `2.13.1` manifest declares
  `@sundaeswap/math@0.3.0` in both `dependencies` and `devDependencies`
- installed only that Core `2.13.1` tarball into a new Bun consumer with no
  lockfile or overrides; Bun resolved Math `0.3.0` and the ESM import of Core,
  `ConstantSumPool`, and `ConcentratedLiquidityPool` passed
- installed the same tarball into a new npm consumer; npm resolved Math `0.3.0`
  and the CommonJS import passed
