### PR TITLE
ci: publish via npm trusted publishing (OIDC)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,5 +10,8 @@
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   },
-  "ignore": ["demo"]
+  "ignore": [
+    "demo",
+    "@sundaeswap/gummiworm"
+  ]
 }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,18 @@ jobs:
       - name: Run Tests
         run: bun test
 
-      # Bump Versions (reinstate after release)
+      # npm >= 11.5.1 performs the OIDC token exchange for trusted
+      # publishing; node 22's bundled npm 10 does not.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@^11.5.1
+
+      # Publishes via npm trusted publishing (OIDC): the job's
+      # `id-token: write` permission lets npm mint a workload credential
+      # scoped to this repo + workflow file — no long-lived registry token.
+      # Each published package names this workflow as its Trusted Publisher
+      # on npmjs.com; a package without that configuration fails to publish.
+      # `changeset publish` skips versions the registry already has, so
+      # re-running after a partial failure is safe.
       - name: Release
         uses: changesets/action@v1
         with:
@@ -46,7 +57,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_TOKEN: ${{ secrets.PUBLISH_NPM_TOKEN }}
 
   # Deploy Documentation
   docs:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typecheck": "lerna run typecheck",
     "build": "lerna run build",
     "version:ci": "lerna version -y --ignore-scripts",
-    "publish:ci": "lerna run publish:prod",
+    "publish:ci": "changeset publish",
     "publish:canary:ci": "lerna run publish:canary",
     "docs": "lerna run docs:ci",
     "dev": "concurrently \"cd packages/core && bun watch\" \"cd packages/yield-farming && bun watch\" \"cd packages/demo && bun start\""

--- a/packages/gummiworm/package.json
+++ b/packages/gummiworm/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@sundaeswap/gummiworm",
+  "private": true,
   "version": "2.0.16",
   "description": "The official SundaeSwap GummiWorm SDK for clients.",
   "repository": "git@github.com:SundaeSwap-finance/sundae-sdk.git",
@@ -12,7 +13,6 @@
   },
   "homepage": "https://github.com/SundaeSwap-finance/sundae-sdk#readme",
   "license": "MIT",
-  "private": false,
   "sideEffects": false,
   "publishConfig": {
     "access": "restricted"


### PR DESCRIPTION
## Why

The 2.14.0 release failed at the publish step: `bun publish` got a 404 on the PUT for `@sundaeswap/core@2.14.0`. npm reports scoped-package auth failures as 404; `PUBLISH_NPM_TOKEN` last worked on 2026-08-12, and npm now puts hard expiries on write tokens. Rotating the token fixes it once; trusted publishing removes the failure class — npm mints a per-run credential from the workflow's OIDC identity, so there is no stored token to expire or leak, and npm attaches provenance attestations to every publish.

## What changes

- **`publish:ci` is now `changeset publish`.** It invokes the npm CLI, which performs the OIDC exchange (`bun publish` does not support trusted publishing). It publishes only versions the registry lacks — replacing both the lerna fan-out and `--tolerate-republish` — and tags releases, which the changesets action pushes.
- **npm is upgraded to ≥ 11.5.1** in the job (node 22 bundles npm 10, which predates trusted publishing).
- **`NPM_CONFIG_TOKEN` is removed** from the Release step. A token in the environment takes precedence over OIDC, so it must go for the exchange to engage. `id-token: write` was already granted on the job.
- Per-package `publish:prod` / `publish:canary` scripts are no longer used by CI; they remain for manual publishes. The commented-out canary block in `branch.yml` is untouched — if canaries are revived, they need their own treatment (a trusted publisher binds to one workflow file).

## Before merging — npmjs.com configuration (maintainer-only)

For **each** published package — `@sundaeswap/core`, `@sundaeswap/math`, `@sundaeswap/cli`, `@sundaeswap/taste-test`, `@sundaeswap/yield-farming` — open the package on npmjs.com → Settings → **Trusted Publisher** → GitHub Actions:

- Organization: `SundaeSwap-finance`
- Repository: `sundae-sdk`
- Workflow filename: `main.yml`
- Environment: leave empty

A package without this configuration fails to publish under this workflow.

`@sundaeswap/gummiworm` is not on the list: it never shipped (nothing on the registry; `publishConfig.access: restricted`; no consumers). A trusted publisher cannot be configured for a package that does not exist, and `changeset publish` would attempt a doomed first publish every release — so this PR marks it `private` and changeset-ignores it, like `demo`.

## After merging

1. The merge push runs the workflow; `changeset publish` publishes `@sundaeswap/core@2.14.0` (versions are already bumped on main) and skips everything the registry already has.
2. Delete the `PUBLISH_NPM_TOKEN` repo secret and revoke the npm token.
3. Optional hardening: in each package's npm settings, restrict publishing access to disallow tokens now that nothing uses them.

## Verification status

YAML parses; `@changesets/cli` 2.29.5 is already a dev dependency; the changesets config already carries `access: public` and ignores `demo`. The publish path itself cannot be exercised from a branch — the first real test is the 2.14.0 re-release after the npm-side configuration and merge.
